### PR TITLE
make set-edoc-hidden call in post compile hook nix specific

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,8 @@
 {provider_hooks, [{pre,  [{compile, {protobuf, compile}}]},
                   {post, [{clean,   {protobuf, clean}}]}]}.
 %% Awesomely bad hack to ensure prometheus_model is hidden from docs.
-{post_hooks, [{compile, "sh bin/set-edoc-hidden src/model/prometheus_model.erl"}]}.
+{post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",
+               compile, "sh bin/set-edoc-hidden src/model/prometheus_model.erl"}]}.
 {gpb_opts, [{i, "src/model"},
             {o_erl, "src/model"},
             {o_hrl, "include"},


### PR DESCRIPTION
There is no sh/bash on windows and not everyone has mingw or cygwin or something like that installed.
I hope windows specific set-hidden script will come later.