### PR TITLE
allow prometheus.erl to be used as a dep in mix projects

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,8 +14,12 @@ defmodule Prometheus.Mixfile do
     """
   end
 
+  def application do
+    [mod: { :prometheus, [] }]
+  end
+
   defp package do
-    [build_tools: ["rebar3"],
+    [build_tools: ["rebar3", "mix"],
      maintainers: ["Ilya Khaprov"],
      licenses: ["MIT"],
      links: %{"GitHub" => "https://github.com/deadtrickster/prometheus.erl",


### PR DESCRIPTION
this adds an application start (mod) key and adds mix to the package metadata to allow prometheus to be used as a dependency from mix