### PR TITLE
Collect allocators

### DIFF
--- a/src/collectors/vm/prometheus_vm_system_info_collector.erl
+++ b/src/collectors/vm/prometheus_vm_system_info_collector.erl
@@ -317,8 +317,8 @@ allocators() ->
     Allocators = erlang:system_info(alloc_util_allocators),
     %% versions is deleted in order to allow the use of the orddict api,
     %% and never really having come across a case where it was useful to know.
-    [{{A,N},lists:sort(proplists:delete(versions,Props))} ||
+    [{{A, N}, lists:sort(proplists:delete(versions, Props))} ||
         A <- Allocators,
-        Allocs <- [erlang:system_info({allocator,A})],
+        Allocs <- [erlang:system_info({allocator, A})],
         Allocs =/= false,
-        {_,N,Props} <- Allocs].
+        {_, N, Props} <- Allocs].

--- a/src/collectors/vm/prometheus_vm_system_info_collector.erl
+++ b/src/collectors/vm/prometheus_vm_system_info_collector.erl
@@ -304,7 +304,7 @@ collect_allocator_metrics() ->
             [
                 allocator_metric(Alloc, Instance, Kind, Key, KindInfo)
             || Key <- [blocks_size, carriers_size]]
-        || {Kind, KindInfo} <- Info, (Kind =:= mbcs) orelse (Kind =:= sbcs)]
+        || {Kind, KindInfo} <- Info, (Kind =:= mbcs) orelse (Kind =:= mbcs_pool) orelse (Kind =:= sbcs)]
     end || {{Alloc, Instance}, Info} <- allocators()]),
     prometheus_model_helpers:gauge_metrics(Metrics).
 

--- a/src/collectors/vm/prometheus_vm_system_info_collector.erl
+++ b/src/collectors/vm/prometheus_vm_system_info_collector.erl
@@ -312,10 +312,9 @@ allocator_metric(Alloc, Instance, Kind, Key, Values) ->
     {[{alloc, Alloc}, {instance, Instance}, {kind, Kind}, {usage, Key}],
         element(2, lists:keyfind(Key, 1, Values))}.
 
-%% Copied from recon_alloc.
+%% Originally copied from recon_alloc.
 allocators() ->
-    UtilAllocators = erlang:system_info(alloc_util_allocators),
-    Allocators = [sys_alloc,mseg_alloc|UtilAllocators],
+    Allocators = erlang:system_info(alloc_util_allocators),
     %% versions is deleted in order to allow the use of the orddict api,
     %% and never really having come across a case where it was useful to know.
     [{{A,N},lists:sort(proplists:delete(versions,Props))} ||

--- a/src/collectors/vm/prometheus_vm_system_info_collector.erl
+++ b/src/collectors/vm/prometheus_vm_system_info_collector.erl
@@ -303,7 +303,7 @@ collect_allocator_metrics() ->
         [
             [
                 allocator_metric(Alloc, Instance, Kind, Key, KindInfo)
-            || Key <- [blocks_size, carriers_size]]
+            || Key <- [blocks, blocks_size, carriers, carriers_size]]
         || {Kind, KindInfo} <- Info, (Kind =:= mbcs) orelse (Kind =:= mbcs_pool) orelse (Kind =:= sbcs)]
     end || {{Alloc, Instance}, Info} <- allocators()]),
     prometheus_model_helpers:gauge_metrics(Metrics).


### PR DESCRIPTION
For all "util" allocators we export the blocks, blocks_size, carriers, carriers_size for the sbcs, mbcs and mbcs_pool of each allocators. This can be used to help tweak the various memory allocator options of the VM.

We will submit a dashboard based on this to https://github.com/deadtrickster/beam-dashboards later today.

cc @gerhard
