### PR TITLE
Accept binary status codes

### DIFF
--- a/src/contrib/prometheus_http.erl
+++ b/src/contrib/prometheus_http.erl
@@ -76,5 +76,7 @@ status_class(SCode) when is_integer(SCode)
                          andalso SCode > 0
                          andalso SCode >= 600 ->
   "unknown";
+status_class(SCode) when is_binary(SCode) ->
+  "unknown";
 status_class(C) ->
   erlang:error({invalid_value, C, "status code must be a positive integer"}).


### PR DESCRIPTION
As the cowboy docs say:

> A binary status can be used to set a reason phrase.

Currently, setting a binary phrase will crash `cowboy_metrics_h`.
This PR addresses this.

https://ninenines.eu/docs/en/cowboy/2.6/manual/cowboy/#_http_status