### PR TITLE
Add erlang_vm_wordsize to system_info collector

### DIFF
--- a/src/collectors/vm/prometheus_vm_system_info_collector.erl
+++ b/src/collectors/vm/prometheus_vm_system_info_collector.erl
@@ -95,6 +95,11 @@
 %%     1 if time correction is enabled, otherwise 0.
 %%   </li>
 %%   <li>
+%%     `erlang_vm_wordsize_bytes'<br/>
+%%     Type: gauge.<br/>
+%%     The size of Erlang term words in bytes.
+%%   </li>
+%%   <li>
 %%     `erlang_vm_atom_count'<br/>
 %%     Type: gauge.<br/>
 %%     The number of atom currently existing at the local node.
@@ -164,6 +169,9 @@
 %%   </li>
 %%   <li>
 %%     `time_correction' for `erlang_vm_time_correction'.
+%%   </li>
+%%   <li>
+%%     `wordsize_bytes' for `erlang_vm_wordsize_bytes'.
 %%   </li>
 %%   <li>
 %%     `atom_count' for `erlang_vm_atom_count'.
@@ -268,6 +276,8 @@ metrics() ->
     "used for asynchronous driver calls."},
    {time_correction, boolean,
     "1 if time correction is enabled, otherwise 0."},
+   {wordsize_bytes, gauge,
+    "The size of Erlang term words in bytes."},
    {atom_count, gauge,
     "The number of atom currently existing "
     "at the local node."},
@@ -282,6 +292,8 @@ metrics() ->
 
 collect_metrics(allocators) ->
     collect_allocator_metrics();
+collect_metrics(wordsize_bytes) ->
+    erlang:system_info(wordsize);
 collect_metrics(Name) ->
   try
     case erlang:system_info(Name) of

--- a/test/eunit/collectors/vm/prometheus_vm_system_info_collector_tests.erl
+++ b/test/eunit/collectors/vm/prometheus_vm_system_info_collector_tests.erl
@@ -32,6 +32,7 @@ test_default_metrics(_) ->
    ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_threads")),
    ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_thread_pool_size")),
    ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_time_correction")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_wordsize_bytes")),
    ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_atom_count")),
    ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_atom_limit"))
   ].
@@ -55,6 +56,7 @@ test_all_metrics(_) ->
                          threads,
                          thread_pool_size,
                          time_correction,
+                         wordsize_bytes,
                          atom_count,
                          atom_limit
                         ]),
@@ -75,6 +77,7 @@ test_all_metrics(_) ->
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_threads")),
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_thread_pool_size")),
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_time_correction")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_wordsize_bytes")),
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_atom_count")),
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_atom_limit"))
     ]
@@ -111,7 +114,8 @@ test_custom_metrics(_) ->
      ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_smp_support")),
      ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_threads")),
      ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_thread_pool_size")),
-     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_time_correction"))
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_time_correction")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_wordsize_bytes"))
     ]
 
   after


### PR DESCRIPTION
Warning: I have not tested it yet.

This value is useful in order to convert values to/from bytes and compare them. There is currently one value in words in the prometheus.erl collectors and it is also available in bytes so this wasn't really necessary. But I am working on adding a collector that has multiple word values and would prefer to avoid providing one value per unit and converting on the collector's side. I think it's best left out for Grafana or other to do when necessary.