### PR TITLE
Add global_labels environment configuration

### DIFF
--- a/test/eunit/collectors/mnesia/prometheus_mnesia_collector_tests.erl
+++ b/test/eunit/collectors/mnesia/prometheus_mnesia_collector_tests.erl
@@ -21,7 +21,8 @@ prometheus_mnesia_on_test_() ->
              prometheus_eunit_common:stop(X) end,
    [fun test_mnesia_on_collector/0,
     fun test_mnesia_on_collector_env_on/0,
-    fun test_mnesia_on_collector_env_off/0]}.
+    fun test_mnesia_on_collector_env_off/0,
+    fun test_mnesia_on_collector_global_labels/0]}.
 
 test_mnesia_on_collector_env_on() ->
   prometheus_registry:register_collector(prometheus_mnesia_collector),
@@ -63,3 +64,13 @@ test_mnesia_on_collector() ->
   ?assertMatch({match,_}, re:run(Metrics, "erlang_mnesia_committed_transactions")),
   ?assertMatch({match,_}, re:run(Metrics, "erlang_mnesia_logged_transactions")),
   ?assertMatch({match,_}, re:run(Metrics, "erlang_mnesia_restarted_transactions")).
+
+test_mnesia_on_collector_global_labels() ->
+  Metrics = try
+    application:set_env(prometheus, global_labels, [{node, node()}]),
+    prometheus_registry:register_collector(prometheus_mnesia_collector),
+    prometheus_text_format:format()
+  after
+    application:unset_env(prometheus, global_labels)
+  end,
+  ?assertMatch({match,_}, re:run(Metrics, "erlang_mnesia_held_locks{node=")).

--- a/test/eunit/collectors/vm/prometheus_vm_memory_collector_tests.erl
+++ b/test/eunit/collectors/vm/prometheus_vm_memory_collector_tests.erl
@@ -8,7 +8,8 @@ prometheus_format_test_() ->
    fun prometheus_eunit_common:stop/1,
    [fun test_default_metrics/1,
     fun test_all_metrics/1,
-    fun test_custom_metrics/1]}.
+    fun test_custom_metrics/1,
+    fun test_global_labels/1]}.
 
 test_default_metrics(_) ->
   prometheus_registry:register_collector(prometheus_vm_memory_collector),
@@ -67,3 +68,16 @@ test_custom_metrics(_) ->
   after
     application:unset_env(prometheus, vm_memory_collector_metrics)
   end.
+
+test_global_labels(_) ->
+  Metrics = try
+    prometheus:start(),
+    application:set_env(prometheus, global_labels, [{node, node()}]),
+    prometheus_registry:register_collector(prometheus_vm_memory_collector),
+    prometheus_text_format:format()
+  after
+    application:unset_env(prometheus, global_labels)
+  end,
+  [
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_memory_atom_bytes_total{node="))
+  ].

--- a/test/eunit/collectors/vm/prometheus_vm_system_info_collector_tests.erl
+++ b/test/eunit/collectors/vm/prometheus_vm_system_info_collector_tests.erl
@@ -8,7 +8,8 @@ prometheus_format_test_() ->
    fun prometheus_eunit_common:stop/1,
    [fun test_default_metrics/1,
     fun test_all_metrics/1,
-    fun test_custom_metrics/1]}.
+    fun test_custom_metrics/1,
+    fun test_global_labels/1]}.
 
 test_default_metrics(_) ->
   prometheus_registry:register_collector(prometheus_vm_system_info_collector),
@@ -116,3 +117,17 @@ test_custom_metrics(_) ->
   after
     application:unset_env(prometheus, vm_system_info_collector_metrics)
   end.
+
+
+test_global_labels(_) ->
+  Metrics = try
+    prometheus:start(),
+    application:set_env(prometheus, global_labels, [{node, node()}]),
+    prometheus_registry:register_collector(prometheus_vm_system_info_collector),
+    prometheus_text_format:format()
+  after
+    application:unset_env(prometheus, global_labels)
+  end,
+  [
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dirty_cpu_schedulers{node="))
+  ].


### PR DESCRIPTION
This allows configuring labels that will be added to ALL metrics
without exception.

#88 

I have added tests for all types of metrics and built-in collectors. I don't know if @gerhard has tested it yet, maybe wait for his OK before merge. If you need some changes or additions you know where to find me!