### PR TITLE
Add node_queue_size metric to dist collector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ cache:
   directories:
   - $HOME/.cache/rebar3/
 otp_release:
-- 20.1
-- 20.0
+- 21.3
+- 22.3
 script: "./bin/checks.sh && ./rebar3 as test coveralls send"

--- a/doc/prometheus_vm_dist_collector.md
+++ b/doc/prometheus_vm_dist_collector.md
@@ -128,6 +128,10 @@ The current state of the distribution link.<br />
 The state is represented as a numerical value where `pending=1`,
 `up_pending=2` and `up=3`.
 
+* `erlang_vm_dist_node_queue_size_bytes`<br/>
+Type: gauge.<br/>
+The number of bytes in the output distribution queue.<br/>
+This queue sits between the Erlang code and the port driver.
 
 
 ### <a name="Configuration">Configuration</a> ###
@@ -185,5 +189,6 @@ Available options:
 
 * `node_state` for `erlang_vm_dist_node_state`.
 
+* `node_queue_size_bytes` for `erlang_vm_dist_node_queue_size_bytes`.
 
 By default all metrics are enabled.

--- a/test/eunit/collectors/vm/prometheus_vm_dist_collector_tests.erl
+++ b/test/eunit/collectors/vm/prometheus_vm_dist_collector_tests.erl
@@ -35,7 +35,8 @@ test_no_distribution(_) ->
    ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_dist_proc_message_queue_len")),
    ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_dist_proc_reductions")),
    ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_dist_proc_status")),
-   ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_dist_node_state"))
+   ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_dist_node_state")),
+   ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_dist_node_queue_size_bytes"))
   ].
 
 
@@ -81,7 +82,8 @@ test_default_metrics(_) ->
    ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_proc_message_queue_len{peer")),
    ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_proc_reductions{peer")),
    ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_proc_status{peer")),
-   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_node_state{peer"))
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_node_state{peer")),
+   ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_node_queue_size_bytes{peer"))
   ].
 
 
@@ -112,7 +114,8 @@ test_all_metrics(_) ->
                          proc_message_queue_len,
                          proc_reductions,
                          proc_status,
-                         node_state
+                         node_state,
+                         node_queue_size_bytes
                         ]),
     prometheus_registry:register_collector(prometheus_vm_dist_collector),
     Metrics = prometheus_text_format:format(),
@@ -140,7 +143,8 @@ test_all_metrics(_) ->
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_proc_message_queue_len")),
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_proc_reductions")),
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_proc_status")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_node_state"))
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_node_state")),
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_node_queue_size_bytes"))
     ]
 
   after
@@ -188,7 +192,8 @@ test_custom_metrics(_) ->
      ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_dist_proc_message_queue_len")),
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_proc_reductions")),
      ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_proc_status")),
-     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_node_state"))
+     ?_assertMatch({match, _}, re:run(Metrics, "erlang_vm_dist_node_state")),
+     ?_assertMatch(nomatch, re:run(Metrics, "erlang_vm_dist_node_queue_size_bytes"))
     ]
 
   after


### PR DESCRIPTION
This depends on https://github.com/erlang/otp/pull/2270 to be really useful. Wait before merging as we're still experimenting.

It's compatible with non-patched OTP versions but the value is simply not useful in that case.