### PR TITLE
Fix incorrect labels type

### DIFF
--- a/doc/prometheus_model_helpers.md
+++ b/doc/prometheus_model_helpers.md
@@ -94,7 +94,7 @@ label_value() = term()
 
 
 <pre><code>
-labels() = [<a href="#type-labels">labels()</a>]
+labels() = [<a href="#type-labels">label()</a>]
 </code></pre>
 
 

--- a/src/model/prometheus_model_helpers.erl
+++ b/src/model/prometheus_model_helpers.erl
@@ -49,7 +49,7 @@
 -type label_name() :: term().
 -type label_value() :: term().
 -type label() :: {label_name(), label_value()}.
--type labels() :: [labels()].
+-type labels() :: [label()].
 -type value() :: float() | integer() | undefined | infinity.
 -type prometheus_boolean() :: boolean() | number() | list() | undefined.
 -type gauge() :: value() | {value()} | {labels(), value()}.


### PR DESCRIPTION
The `labels` type is incorrectly defined as `[labels()]`, it should be `[label()]` instead.