### PR TITLE
fix some 404s in the docs

### DIFF
--- a/doc/prometheus_mnesia.md
+++ b/doc/prometheus_mnesia.md
@@ -57,7 +57,7 @@ Mnesia can create different files for each table:
 More on Mnesia files can be found in
 [
 Mnesia System Information chapter
-](http://erlang.org/doc/apps/mnesia/Mnesia_chap7.md) of Mnesia User's Guide
+](http://erlang.org/doc/apps/mnesia/Mnesia_chap7.html) of Mnesia User's Guide
 
 <a name="tm_info-0"></a>
 

--- a/doc/prometheus_mnesia_collector.md
+++ b/doc/prometheus_mnesia_collector.md
@@ -6,7 +6,7 @@
 Collects Mnesia metrics mainly using
 [
 mnesia:system_info/1
-](http://erlang.org/doc/man/mnesia.md#system_info-1).
+](http://erlang.org/doc/man/mnesia.html#system_info-1).
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 

--- a/doc/prometheus_vm_memory_collector.md
+++ b/doc/prometheus_vm_memory_collector.md
@@ -7,7 +7,7 @@ Collects information about memory dynamically allocated
 by the Erlang emulator using
 [
 erlang:memory/0
-](http://erlang.org/doc/man/erlang.md#memory-0), also provides basic (D)ETS statistics.
+](http://erlang.org/doc/man/erlang.html#memory-0), also provides basic (D)ETS statistics.
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 

--- a/doc/prometheus_vm_statistics_collector.md
+++ b/doc/prometheus_vm_statistics_collector.md
@@ -6,7 +6,7 @@
 Collects Erlang VM metrics using
 [
 erlang:statistics/1
-](http://erlang.org/doc/man/erlang.md#statistics-1).
+](http://erlang.org/doc/man/erlang.html#statistics-1).
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 
@@ -80,7 +80,7 @@ Metrics exported by this collector can be configured via
 Options are the same as Item parameter values for
 [
 erlang:statistics/1
-](http://erlang.org/doc/man/erlang.md#statistics-1):
+](http://erlang.org/doc/man/erlang.html#statistics-1):
 
 * `context_switches` for `erlang_vm_statistics_context_switches`;
 

--- a/doc/prometheus_vm_system_info_collector.md
+++ b/doc/prometheus_vm_system_info_collector.md
@@ -6,7 +6,7 @@
 Collects Erlang VM metrics using
 [
 erlang:system_info/1
-](http://erlang.org/doc/man/erlang.md#system_info-1).
+](http://erlang.org/doc/man/erlang.html#system_info-1).
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 
@@ -112,7 +112,7 @@ Metrics exported by this collector can be configured via
 Options are the same as Item parameter values for
 [
 erlang:system_info/1
-](http://erlang.org/doc/man/erlang.md#system_info-1):
+](http://erlang.org/doc/man/erlang.html#system_info-1):
 
 * `ets_limit` for `erlang_vm_ets_limit`.
 


### PR DESCRIPTION
all the `.md`-links to the erlang docs seem to 404