### PR TITLE
Added functions `clear/1,2,3` to all metrics

### DIFF
--- a/src/metrics/prometheus_boolean.erl
+++ b/src/metrics/prometheus_boolean.erl
@@ -45,6 +45,9 @@
          reset/1,
          reset/2,
          reset/3,
+         clear/1,
+         clear/2,
+         clear/3,
          value/1,
          value/2,
          value/3,
@@ -227,6 +230,26 @@ reset(Name, LabelValues) ->
 reset(Registry, Name, LabelValues) ->
   prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
   ets:update_element(?TABLE, {Registry, Name, LabelValues}, {?BOOLEAN_POS, 0}).
+
+%% @equiv clear(default, Name, [])
+clear(Name) ->
+  clear(default, Name, []).
+
+%% @equiv clear(default, Name, LabelValues)
+clear(Name, LabelValues) ->
+  clear(default, Name, LabelValues).
+
+%% @doc Clear the value of the boolean identified by `Registry', `Name'
+%% and `LabelValues'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if boolean with name `Name'
+%% can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% @end
+clear(Registry, Name, LabelValues) ->
+  prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
+  ets:delete(?TABLE, {Registry, Name, LabelValues}).
 
 %% @equiv value(default, Name, [])
 value(Name) ->

--- a/src/metrics/prometheus_counter.erl
+++ b/src/metrics/prometheus_counter.erl
@@ -68,6 +68,9 @@
          reset/1,
          reset/2,
          reset/3,
+         clear/1,
+         clear/2,
+         clear/3,
          value/1,
          value/2,
          value/3,
@@ -256,6 +259,29 @@ reset(Registry, Name, LabelValues) ->
     _ -> false
   end.
 
+%% @equiv clear(default, Name, [])
+clear(Name) ->
+  clear(default, Name, []).
+
+%% @equiv clear(default, Name, LabelValues)
+clear(Name, LabelValues) ->
+  clear(default, Name, LabelValues).
+
+%% @doc Clear the value of the counter identified by `Registry', `Name'
+%% and `LabelValues'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if boolean with name `Name'
+%% can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% @end
+clear(Registry, Name, LabelValues) ->
+  prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
+  case ets:select_delete(?TABLE, clear_select(Registry, Name, LabelValues)) of
+    0 -> false;
+    _ -> true
+  end.
+
 %% @equiv value(default, Name, [])
 value(Name) ->
   value(default, Name, []).
@@ -328,6 +354,9 @@ collect_metrics(Name, {CLabels, Labels, Registry}) ->
 
 deregister_select(Registry, Name) ->
   [{{{Registry, Name, '_', '_'}, '_', '_'}, [], [true]}].
+
+clear_select(Registry, Name, LabelValues) ->
+  [{{{Registry, Name, LabelValues, '_'}, '_', '_'}, [], [true]}].
 
 insert_metric(Registry, Name, LabelValues, Value, ConflictCB) ->
   prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),

--- a/src/metrics/prometheus_gauge.erl
+++ b/src/metrics/prometheus_gauge.erl
@@ -71,6 +71,9 @@
          reset/1,
          reset/2,
          reset/3,
+         clear/1,
+         clear/2,
+         clear/3,
          value/1,
          value/2,
          value/3,
@@ -389,6 +392,26 @@ reset(Name, LabelValues) ->
 reset(Registry, Name, LabelValues) ->
   prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
   ets:update_element(?TABLE, {Registry, Name, LabelValues}, [{?IGAUGE_POS, 0}, {?FGAUGE_POS, 0}]).
+
+%% @equiv clear(default, Name, [])
+clear(Name) ->
+  clear(default, Name, []).
+
+%% @equiv clear(default, Name, LabelValues)
+clear(Name, LabelValues) ->
+  clear(default, Name, LabelValues).
+
+%% @doc Clear the value of the gauge identified by `Registry', `Name'
+%% and `LabelValues'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if boolean with name `Name'
+%% can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% @end
+clear(Registry, Name, LabelValues) ->
+  prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
+  ets:delete(?TABLE, {Registry, Name, LabelValues}).
 
 %% @equiv value(default, Name, [])
 value(Name) ->

--- a/src/metrics/prometheus_histogram.erl
+++ b/src/metrics/prometheus_histogram.erl
@@ -52,6 +52,9 @@
          reset/1,
          reset/2,
          reset/3,
+         clear/1,
+         clear/2,
+         clear/3,
          value/1,
          value/2,
          value/3,
@@ -329,6 +332,31 @@ reset(Registry, Name, LabelValues) ->
     _ -> false
   end.
 
+%% @equiv clear(default, Name, [])
+clear(Name) ->
+  clear(default, Name, []).
+
+%% @equiv clear(default, Name, LabelValues)
+clear(Name, LabelValues) ->
+  clear(default, Name, LabelValues).
+
+%% @doc Clear the value of the histogram identified by `Registry', `Name'
+%% and `LabelValues'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if histogram with name
+%% `Name' can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% @end
+clear(Registry, Name, LabelValues) ->
+  MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
+  Buckets = prometheus_metric:mf_data(MF),
+
+  case ets:select_delete(?TABLE, clear_select(Registry, Name, LabelValues, Buckets)) of
+    0 -> false;
+    _ -> true
+  end.
+
 %% @equiv value(default, Name, [])
 value(Name) ->
   value(default, Name, []).
@@ -424,6 +452,11 @@ collect_metrics(Name, {CLabels, Labels, Registry, DU, Bounds}) ->
 %%====================================================================
 %% Private Parts
 %%====================================================================
+
+clear_select(Registry, Name, LabelValues, Buckets) ->
+  BoundCounters = lists:duplicate(length(Buckets), '_'),
+  MetricSpec = [{Registry, Name, LabelValues, '_'}, '_', '_', '_'] ++ BoundCounters,
+  [{list_to_tuple(MetricSpec), [], [true]}].
 
 validate_histogram_spec(Spec) ->
   Labels = prometheus_metric_spec:labels(Spec),

--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -44,6 +44,9 @@
          reset/1,
          reset/2,
          reset/3,
+         clear/1,
+         clear/2,
+         clear/3,
          value/1,
          value/2,
          value/3,
@@ -255,6 +258,29 @@ reset(Registry, Name, LabelValues) ->
     _ -> false
   end.
 
+%% @equiv clear(default, Name, [])
+clear(Name) ->
+  clear(default, Name, []).
+
+%% @equiv clear(default, Name, LabelValues)
+clear(Name, LabelValues) ->
+  clear(default, Name, LabelValues).
+
+%% @doc Clear the value of the summary identified by `Registry', `Name'
+%% and `LabelValues'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if summary with name `Name'
+%% can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% @end
+clear(Registry, Name, LabelValues) ->
+  prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
+  case ets:select_delete(?TABLE, clear_select(Registry, Name, LabelValues)) of
+    0 -> false;
+    _ -> true
+  end.
+
 %% @equiv value(default, Name, [])
 value(Name) ->
   value(default, Name, []).
@@ -336,6 +362,9 @@ collect_metrics(Name, {CLabels, Labels, Registry, DU}) ->
 
 deregister_select(Registry, Name) ->
   [{{{Registry, Name, '_', '_'}, '_', '_', '_'}, [], [true]}].
+
+clear_select(Registry, Name, LabelValues) ->
+  [{{{Registry, Name, LabelValues, '_'}, '_', '_', '_'}, [], [true]}].
 
 validate_summary_spec(Spec) ->
   Labels = prometheus_metric_spec:labels(Spec),

--- a/test/eunit/metric/prometheus_boolean_tests.erl
+++ b/test/eunit/metric/prometheus_boolean_tests.erl
@@ -60,6 +60,10 @@ test_errors(_) ->
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_boolean:reset(with_label, [repo, db])),
    ?_assertError({unknown_metric, default, unknown_metric},
+                 prometheus_boolean:clear(unknown_metric)),
+   ?_assertError({invalid_metric_arity, 2, 1},
+                 prometheus_boolean:clear(with_label, [repo, db])),
+   ?_assertError({unknown_metric, default, unknown_metric},
                  prometheus_boolean:value(unknown_metric)),
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_boolean:value(with_label, [repo, db])),
@@ -85,9 +89,12 @@ test_set(_) ->
   Value1 = prometheus_boolean:value(fuse_state, [mongodb]),
   prometheus_boolean:reset(fuse_state, [mongodb]),
   RValue = prometheus_boolean:value(fuse_state, [mongodb]),
+  prometheus_boolean:clear(fuse_state, [mongodb]),
+  CValue = prometheus_boolean:value(fuse_state, [mongodb]),
   [?_assertEqual(true, Value),
    ?_assertEqual(false, Value1),
-   ?_assertEqual(false, RValue)].
+   ?_assertEqual(false, RValue),
+   ?_assertEqual(undefined, CValue)].
 
 test_toggle(_) ->
   prometheus_boolean:new([{name, fuse_state}, {labels, [name]}, {help, ""}]),

--- a/test/eunit/metric/prometheus_counter_tests.erl
+++ b/test/eunit/metric/prometheus_counter_tests.erl
@@ -56,6 +56,10 @@ test_errors(_) ->
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_counter:reset(db_query_duration, [repo, db])),
    ?_assertError({unknown_metric, default, unknown_metric},
+                 prometheus_counter:clear(unknown_metric)),
+   ?_assertError({invalid_metric_arity, 2, 1},
+                 prometheus_counter:clear(db_query_duration, [repo, db])),
+   ?_assertError({unknown_metric, default, unknown_metric},
                  prometheus_counter:value(unknown_metric)),
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_counter:value(db_query_duration, [repo, db])),
@@ -75,8 +79,11 @@ test_inc(_) ->
   Value = prometheus_counter:value(http_requests_total, [get]),
   prometheus_counter:reset(http_requests_total, [get]),
   RValue = prometheus_counter:value(http_requests_total, [get]),
+  prometheus_counter:clear(http_requests_total, [get]),
+  CValue = prometheus_counter:value(http_requests_total, [get]),
   [?_assertMatch(_ when Value > 7.4 andalso Value < 7.6, Value),
-   ?_assertEqual(0, RValue)].
+   ?_assertEqual(0, RValue),
+   ?_assertEqual(undefined, CValue)].
 
 test_deregister(_) ->
   prometheus_counter:new([{name, http_requests_total},

--- a/test/eunit/metric/prometheus_gauge_tests.erl
+++ b/test/eunit/metric/prometheus_gauge_tests.erl
@@ -84,6 +84,10 @@ test_errors(_) ->
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_gauge:reset(with_label, [repo, db])),
    ?_assertError({unknown_metric, default, unknown_metric},
+                 prometheus_gauge:clear(unknown_metric)),
+   ?_assertError({invalid_metric_arity, 2, 1},
+                 prometheus_gauge:clear(with_label, [repo, db])),
+   ?_assertError({unknown_metric, default, unknown_metric},
                  prometheus_gauge:value(unknown_metric)),
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_gauge:value(with_label, [repo, db])),
@@ -101,9 +105,12 @@ test_set(_) ->
   Value1 = prometheus_gauge:value(pool_size, [mongodb]),
   prometheus_gauge:reset(pool_size, [mongodb]),
   RValue = prometheus_gauge:value(pool_size, [mongodb]),
+  prometheus_gauge:clear(pool_size, [mongodb]),
+  CValue = prometheus_gauge:value(pool_size, [mongodb]),
   [?_assertEqual(100, Value),
    ?_assertEqual(105, Value1),
-   ?_assertEqual(0, RValue)].
+   ?_assertEqual(0, RValue),
+   ?_assertEqual(undefined, CValue)].
 
 test_inc(_) ->
   prometheus_gauge:new([{name, pool_size}, {labels, [client]}, {help, ""}]),

--- a/test/eunit/metric/prometheus_histogram_tests.erl
+++ b/test/eunit/metric/prometheus_histogram_tests.erl
@@ -69,6 +69,10 @@ test_errors(_) ->
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_histogram:reset(db_query_duration, [repo, db])),
    ?_assertError({unknown_metric, default, unknown_metric},
+                 prometheus_histogram:clear(unknown_metric)),
+   ?_assertError({invalid_metric_arity, 2, 1},
+                 prometheus_histogram:clear(db_query_duration, [repo, db])),
+   ?_assertError({unknown_metric, default, unknown_metric},
                  prometheus_histogram:value(unknown_metric)),
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_histogram:value(db_query_duration, [repo, db])),
@@ -163,9 +167,12 @@ test_observe(_) ->
   Value = prometheus_histogram:value(http_request_duration_milliseconds, [get]),
   prometheus_histogram:reset(http_request_duration_milliseconds, [get]),
   RValue = prometheus_histogram:value(http_request_duration_milliseconds, [get]),
+  prometheus_histogram:clear(http_request_duration_milliseconds, [get]),
+  CValue = prometheus_histogram:value(http_request_duration_milliseconds, [get]),
   [?_assertMatch({[3, 4, 2, 2, 3, 1], Sum}
                  when Sum > 6974.5 andalso Sum < 6974.55, Value),
-   ?_assertEqual({[0, 0, 0, 0, 0, 0], 0}, RValue)].
+   ?_assertEqual({[0, 0, 0, 0, 0, 0], 0}, RValue),
+   ?_assertEqual(undefined, CValue)].
 
 test_observe_duration_seconds(_) ->
   prometheus_histogram:new([{name, fun_duration_seconds},

--- a/test/eunit/metric/prometheus_summary_tests.erl
+++ b/test/eunit/metric/prometheus_summary_tests.erl
@@ -62,6 +62,10 @@ test_errors(_) ->
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_summary:reset(db_query_duration, [repo, db])),
    ?_assertError({unknown_metric, default, unknown_metric},
+                 prometheus_summary:clear(unknown_metric)),
+   ?_assertError({invalid_metric_arity, 2, 1},
+                 prometheus_summary:clear(db_query_duration, [repo, db])),
+   ?_assertError({unknown_metric, default, unknown_metric},
                  prometheus_summary:value(unknown_metric)),
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_summary:value(db_query_duration, [repo, db])),
@@ -88,8 +92,11 @@ test_observe(_) ->
   Value = prometheus_summary:value(orders_summary, [electronics]),
   prometheus_summary:reset(orders_summary, [electronics]),
   RValue = prometheus_summary:value(orders_summary, [electronics]),
+  prometheus_summary:clear(orders_summary, [electronics]),
+  CValue = prometheus_summary:value(orders_summary, [electronics]),
   [?_assertMatch({4, Sum} when Sum > 29.1 andalso Sum < 29.3, Value),
-   ?_assertEqual({0, 0}, RValue)].
+   ?_assertEqual({0, 0}, RValue),
+   ?_assertEqual(undefined, CValue)].
 
 test_observe_duration_seconds(_) ->
   prometheus_summary:new([{name, <<"fun_duration_seconds">>},


### PR DESCRIPTION
This PR adds functions `clear/1,2,3` to all metrics allowing users to clear (erase) existing metrics. This is useful case the app needs to stop (interrupt) certain metrics along its lifecycle.