### PR TITLE
persisting metrics using prometheus_sup:register_metrics/1

### DIFF
--- a/src/prometheus_sup.erl
+++ b/src/prometheus_sup.erl
@@ -9,6 +9,7 @@
 -export([start_link/0]).
 %% Supervisor callbacks
 -export([init/1]).
+-export([register_metrics/1]).
 
 -behaviour(supervisor).
 
@@ -61,6 +62,12 @@ register_collectors() ->
 
 register_metrics() ->
   [declare_metric(Decl) || Decl <- default_metrics()].
+
+register_metrics(Metrics) ->
+  DefaultMetrics0 = default_metrics(),
+  DefaultMetrics1 = lists:usort(DefaultMetrics0 ++ Metrics),
+  application:set_env(prometheus, default_metrics, DefaultMetrics1),
+  [declare_metric(Decl) || Decl <- Metrics].
 
 setup_instrumenters() ->
   [prometheus_instrumenter:setup(Instrumenter) ||


### PR DESCRIPTION
Currently, when an app declares metrics, they are stored in ets tables and if prometheus is restarted for any reason (which has happened in our case), all previously registered metrics will be lost and the calling application will crash since the metrics no longer exist on the side of prometheus.
This forces users to define metrics in sys.config under entry of "default_metrics" so that they are preserved across app restarts, however this is sometimes inconvenient.
This pull request fixes this problem by allowing users to register metrics via. code using the same format as used in sys.config which are preserved across app restarts. 