### PR TITLE
Tablewise Mnesia Metrics ... Optimized collect_metric for summaries and better metric registrations

### DIFF
--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -294,12 +294,21 @@ values(Registry, Name) ->
       DU = prometheus_metric:mf_duration_unit(MF),
       Labels = prometheus_metric:mf_labels(MF),
       MFValues = load_all_values(Registry, Name),
-      [begin
-         {Count, Sum} = reduce_label_values(LabelValues, MFValues),
-         {lists:zip(Labels, LabelValues), Count,
-          prometheus_time:maybe_convert_to_du(DU, Sum)}
-       end ||
-        LabelValues <- collect_unique_labels(MFValues)]
+      ReducedMap = lists:foldl(
+        fun([L, C, IS, FS], ResAcc) ->
+          {PrevCount, PrevSum} = maps:get(L, ResAcc, {0,0}),
+          ResAcc#{L => {PrevCount + C, PrevSum + IS + FS}}
+        end,
+      #{},
+      MFValues),
+      ReducedMapList = lists:sort(maps:to_list(ReducedMap)),
+      lists:foldr(
+        fun({LabelValues, {Count, Sum}}, Acc) ->
+          [{lists:zip(Labels, LabelValues), Count,
+          prometheus_time:maybe_convert_to_du(DU, Sum)} | Acc]
+        end,
+        [],
+      ReducedMapList)
   end.
 
 %%====================================================================
@@ -322,13 +331,22 @@ collect_mf(Registry, Callback) ->
 %% @private
 collect_metrics(Name, {CLabels, Labels, Registry, DU}) ->
   MFValues = load_all_values(Registry, Name),
-  [begin
-     {Count, Sum} = reduce_label_values(LabelValues, MFValues),
-     prometheus_model_helpers:summary_metric(
-       CLabels ++ lists:zip(Labels, LabelValues), Count,
-       prometheus_time:maybe_convert_to_du(DU, Sum))
-   end ||
-    LabelValues <- collect_unique_labels(MFValues)].
+  ReducedMap = lists:foldl(
+        fun([L, C, IS, FS], ResAcc) ->
+          {PrevCount, PrevSum} = maps:get(L, ResAcc, {0,0}),
+          ResAcc#{L => {PrevCount + C, PrevSum + IS + FS}}
+        end,
+      #{},
+      MFValues),
+  ReducedMapList = lists:sort(maps:to_list(ReducedMap)),
+  lists:foldr(
+    fun({LabelValues, {Count, Sum}}, Acc) ->
+      [prometheus_model_helpers:summary_metric(
+      CLabels ++ lists:zip(Labels, LabelValues), Count,
+      prometheus_time:maybe_convert_to_du(DU, Sum)) | Acc]
+    end,
+    [],
+  ReducedMapList).
 
 %%====================================================================
 %% Private Parts
@@ -370,13 +388,6 @@ key(Registry, Name, LabelValues) ->
   X = erlang:system_info(scheduler_id),
   Rnd = X band (?WIDTH-1),
   {Registry, Name, LabelValues, Rnd}.
-
-collect_unique_labels(MFValues) ->
-  lists:usort([L || [L, _, _, _] <- MFValues]).
-
-reduce_label_values(Labels, MFValues) ->
-  {lists:sum([C || [L, C, _, _] <- MFValues, L == Labels]),
-   lists:sum([IS + FS || [L, _, IS, FS] <- MFValues, L == Labels])}.
 
 reduce_values(Values) ->
   {lists:sum([C || [C, _, _] <- Values]),

--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -296,7 +296,7 @@ values(Registry, Name) ->
       MFValues = load_all_values(Registry, Name),
       ReducedMap = lists:foldl(
         fun([L, C, IS, FS], ResAcc) ->
-          {PrevCount, PrevSum} = maps:get(L, ResAcc, {0,0}),
+          {PrevCount, PrevSum} = maps:get(L, ResAcc, {0, 0}),
           ResAcc#{L => {PrevCount + C, PrevSum + IS + FS}}
         end,
       #{},
@@ -333,7 +333,7 @@ collect_metrics(Name, {CLabels, Labels, Registry, DU}) ->
   MFValues = load_all_values(Registry, Name),
   ReducedMap = lists:foldl(
         fun([L, C, IS, FS], ResAcc) ->
-          {PrevCount, PrevSum} = maps:get(L, ResAcc, {0,0}),
+          {PrevCount, PrevSum} = maps:get(L, ResAcc, {0, 0}),
           ResAcc#{L => {PrevCount + C, PrevSum + IS + FS}}
         end,
       #{},

--- a/src/prometheus_sup.erl
+++ b/src/prometheus_sup.erl
@@ -9,6 +9,7 @@
 -export([start_link/0]).
 %% Supervisor callbacks
 -export([init/1]).
+-export([register_metrics/1]).
 
 -behaviour(supervisor).
 
@@ -61,6 +62,12 @@ register_collectors() ->
 
 register_metrics() ->
   [declare_metric(Decl) || Decl <- default_metrics()].
+
+register_metrics(Metrics) ->
+  DefaultMetrics0 = default_metrics(),
+  DefaultMetrics1 = lists:usort(DefaultMetrics0 ++ Metrics),
+  application:set_env(prometheus, default_metrics, DefaultMetrics1),
+  [declare_metric(Decl) || Decl <- Metrics].
 
 setup_instrumenters() ->
   [prometheus_instrumenter:setup(Instrumenter) ||


### PR DESCRIPTION
This PR introduces following enhancements/fixes:

1. Tablewise Mnesia Metrics: We wished to put alerts on per table row size / mem size and thought it will be a good contribution for everyone.

2. Optimized collect_metric for summaries which was taking long time for many series of summaries (~9s), after optimization it completes under 500ms using O(N) instead of earlier O(N^2) implementation.

3. Better Metric Registration: If prometheus app is restarted then all metrics all lost and caller apps start crashing because those metrics are no longer defined. Using prometheus_sup:register_metrics, they are persisted in environment vars so upon restart they are reinitialized automatically.