### PR TITLE
replace regex to escape special chars with simple binary comprehension

### DIFF
--- a/test/eunit/format/prometheus_text_format_tests.erl
+++ b/test/eunit/format/prometheus_text_format_tests.erl
@@ -21,11 +21,11 @@ create_untyped(Name, Help) ->
   prometheus_model_helpers:create_mf(Name, Help, untyped, ?MODULE, undefined).
 
 escape_metric_help_test() ->
-  ?assertEqual("qwe\\\\qwe\\nqwe",
+  ?assertEqual(<<"qwe\\\\qwe\\nqwe">>,
                prometheus_text_format:escape_metric_help("qwe\\qwe\nqwe")).
 
 escape_label_value_test()->
-  ?assertEqual("qwe\\\\qwe\\nq\\\"we\\\"qwe",
+  ?assertEqual(<<"qwe\\\\qwe\\nq\\\"we\\\"qwe">>,
                prometheus_text_format:escape_label_value("qwe\\qwe\nq\"we\"qwe")).
 
 prometheus_format_test_() ->


### PR DESCRIPTION
Running regex (especially three times in a row) is much more expensive
that a binary comprehension. This makes little difference for small
data sets, for anything beyond a few hundred items it becomes measurable.
Data sets beyond a few thousand items are completely unusable without
this change.