### PR TITLE
RabbitMQ license has changed to MPL2

### DIFF
--- a/src/prometheus_misc.erl
+++ b/src/prometheus_misc.erl
@@ -1,20 +1,12 @@
 %% @hidden
 %% behaviour_modules original Copyright message
 %% all other code is under MIT
-%% The contents of this file are subject to the Mozilla Public License
-%% Version 1.1 (the "License"); you may not use this file except in
-%% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
 %%
-%% Software distributed under the License is distributed on an "AS IS"
-%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
-%% the License for the specific language governing rights and
-%% limitations under the License.
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% The Original Code is RabbitMQ.
-%%
-%% The Initial Developer of the Original Code is GoPivotal, Inc.
-%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(prometheus_misc).


### PR DESCRIPTION
so license header in `prometheus_misc` has to be updated.

This shows up as a transient MPLv1.1 dependency on VMware open source
compliance reviews.