### PR TITLE
Fix links to Erlang/OTP official document

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ API can be grouped like this:
 All metrics created via `new/1` or `declare/1`. The difference is that `new/1` actually wants metric to be
 new and raises `{mf_already_exists, {Registry, Name}, Message}` error if it isn't.
 
-Both `new/1` and `declare/1` accept options as [proplist](http://erlang.org/doc/man/proplists.html).
+Both `new/1` and `declare/1` accept options as [proplist](http://www.erlang.org/doc/man/proplists.html).
 Common options are:
 
 - name - metric name, can be an atom or a string (required);

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2016,2017 Ilya Khaprov <<i.khaprov@gmail.com>>.
 
-__Version:__ 4.8.1
+__Version:__ 4.8.2
 
 [![Hex.pm](https://img.shields.io/hexpm/v/prometheus.svg?maxAge=2592000?style=plastic)](https://hex.pm/packages/prometheus)
 [![Hex.pm](https://img.shields.io/hexpm/dt/prometheus.svg?maxAge=2592000)](https://hex.pm/packages/prometheus)

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -154,7 +154,7 @@ API can be grouped like this:
 All metrics created via `new/1' or `declare/1'. The difference is that `new/1' actually wants metric to be
 new and raises `{mf_already_exists, {Registry, Name}, Message}' error if it isn't.
 
-Both `new/1' and `declare/1' accept options as [proplist](http://erlang.org/doc/man/proplists.html).
+Both `new/1' and `declare/1' accept options as [proplist](http://www.erlang.org/doc/man/proplists.html).
 Common options are:
 
 - name - metric name, can be an atom or a string (required);

--- a/doc/prometheus_collector.md
+++ b/doc/prometheus_collector.md
@@ -80,7 +80,7 @@ Example (simplified `prometheus_vm_memory_collector`):
 
 
 <pre><code>
-collect_mf_callback() = fun((<a href="prometheus_model.md#type-MetricFamily">prometheus_model:'MetricFamily'()</a>) -&gt; any())
+collect_mf_callback() = fun((<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-MetricFamily">prometheus_model:'MetricFamily'()</a>) -&gt; any())
 </code></pre>
 
 
@@ -123,7 +123,7 @@ data() = any()
 collect_mf(Registry, Collector, Callback) -&gt; ok
 </code></pre>
 
-<ul class="definitions"><li><code>Registry = <a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a></code></li><li><code>Collector = <a href="#type-collector">collector()</a></code></li><li><code>Callback = <a href="#type-collect_mf_callback">collect_mf_callback()</a></code></li></ul>
+<ul class="definitions"><li><code>Registry = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a></code></li><li><code>Collector = <a href="#type-collector">collector()</a></code></li><li><code>Callback = <a href="#type-collect_mf_callback">collect_mf_callback()</a></code></li></ul>
 
 Calls `Callback` for each MetricFamily of this collector.
 

--- a/doc/prometheus_counter.md
+++ b/doc/prometheus_counter.md
@@ -39,7 +39,7 @@ To create a counter use either [`new/1`](#new-1) or [`declare/1`](#declare-1),
 the difference is that [`new/1`](#new-1) will raise
 {:mf_already_exists, {Registry, Name}, Message} error if counter with
 the same `Registry`, `Name` and `Labels` combination already exists.
-Both accept `Spec` [proplist](http://erlang.org/doc/man/proplists.html)
+Both accept `Spec` [proplist](http://www.erlang.org/doc/man/proplists.html)
 with the same set of keys:
 
 - `Registry` - optional, default is `default`;

--- a/doc/prometheus_http.md
+++ b/doc/prometheus_http.md
@@ -19,7 +19,7 @@ HTTP instrumentation helpers.
 
 
 <pre><code>
-status_class() = <a href="prometheus_model_helpers.md#type-label_value">prometheus_model_helpers:label_value()</a>
+status_class() = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model_helpers.html#type-label_value">prometheus_model_helpers:label_value()</a>
 </code></pre>
 
 
@@ -51,7 +51,7 @@ Returns status class for the http status code <code>SCode</code>.</td></tr></tab
 ### microseconds_duration_buckets/0 ###
 
 <pre><code>
-microseconds_duration_buckets() -&gt; <a href="prometheus_buckets.md#type-buckets">prometheus_buckets:buckets()</a>
+microseconds_duration_buckets() -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_buckets.html#type-buckets">prometheus_buckets:buckets()</a>
 </code></pre>
 <br />
 

--- a/doc/prometheus_mnesia.md
+++ b/doc/prometheus_mnesia.md
@@ -57,7 +57,7 @@ Mnesia can create different files for each table:
 More on Mnesia files can be found in
 [
 Mnesia System Information chapter
-](http://erlang.org/doc/apps/mnesia/Mnesia_chap7.md) of Mnesia User's Guide
+](http://www.erlang.org/doc/apps/mnesia/Mnesia_chap7.html) of Mnesia User's Guide
 
 <a name="tm_info-0"></a>
 

--- a/doc/prometheus_mnesia.md
+++ b/doc/prometheus_mnesia.md
@@ -31,7 +31,7 @@ CCount is a number of coordinator transactions.</td></tr></table>
 table_disk_size(Table) -&gt; Size
 </code></pre>
 
-<ul class="definitions"><li><code>Table = <a href="file.md#type-name_all">file:name_all()</a></code></li><li><code>Size = non_neg_integer()</code></li></ul>
+<ul class="definitions"><li><code>Table = <a href="http://www.erlang.org/edoc/doc/kernel/doc/file.html#type-name_all">file:name_all()</a></code></li><li><code>Size = non_neg_integer()</code></li></ul>
 
 Equivalent to [`table_disk_size(mnesia:system_info(directory), Table)`](#table_disk_size-2).
 
@@ -43,7 +43,7 @@ Equivalent to [`table_disk_size(mnesia:system_info(directory), Table)`](#table_d
 table_disk_size(Dir, Table) -&gt; Size
 </code></pre>
 
-<ul class="definitions"><li><code>Dir = <a href="file.md#type-name_all">file:name_all()</a></code></li><li><code>Table = <a href="file.md#type-name_all">file:name_all()</a></code></li><li><code>Size = non_neg_integer()</code></li></ul>
+<ul class="definitions"><li><code>Dir = <a href="http://www.erlang.org/edoc/doc/kernel/doc/file.html#type-name_all">file:name_all()</a></code></li><li><code>Table = <a href="http://www.erlang.org/edoc/doc/kernel/doc/file.html#type-name_all">file:name_all()</a></code></li><li><code>Size = non_neg_integer()</code></li></ul>
 
 Returns sum of all mnesia files for the given `Table` in bytes.
 Mnesia can create different files for each table:

--- a/doc/prometheus_mnesia_collector.md
+++ b/doc/prometheus_mnesia_collector.md
@@ -6,7 +6,7 @@
 Collects Mnesia metrics mainly using
 [
 mnesia:system_info/1
-](http://erlang.org/doc/man/mnesia.md#system_info-1).
+](http://www.erlang.org/doc/man/mnesia.html#system_info-1).
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 

--- a/doc/prometheus_model_helpers.md
+++ b/doc/prometheus_model_helpers.md
@@ -24,7 +24,7 @@ Probably will be used with [`prometheus_collector`](prometheus_collector.md).
 
 
 <pre><code>
-buckets() = [{<a href="prometheus_buckets.md#type-bucket_bound">prometheus_buckets:bucket_bound()</a>, non_neg_integer()}, ...]
+buckets() = [{<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_buckets.html#type-bucket_bound">prometheus_buckets:bucket_bound()</a>, non_neg_integer()}, ...]
 </code></pre>
 
 
@@ -94,7 +94,7 @@ label_value() = term()
 
 
 <pre><code>
-labels() = [<a href="#type-label">label()</a>]
+labels() = [<a href="#type-label">label()</a>] | <a href="#type-pre_rendered_labels">pre_rendered_labels()</a>
 </code></pre>
 
 
@@ -115,6 +115,16 @@ metrics() = <a href="#type-tmetric">tmetric()</a> | [<a href="#type-tmetric">tme
 
 <pre><code>
 pbool() = <a href="#type-prometheus_boolean">prometheus_boolean()</a> | {<a href="#type-prometheus_boolean">prometheus_boolean()</a>} | {<a href="#type-labels">labels()</a>, <a href="#type-prometheus_boolean">prometheus_boolean()</a>}
+</code></pre>
+
+
+
+
+### <a name="type-pre_rendered_labels">pre_rendered_labels()</a> ###
+
+
+<pre><code>
+pre_rendered_labels() = binary()
 </code></pre>
 
 
@@ -176,33 +186,33 @@ value() = float() | integer() | undefined | infinity
 Equivalent to
 <a href="#boolean_metric-2"><tt>boolean_metric(Labels, Value)</tt></a>.</td></tr><tr><td valign="top"><a href="#boolean_metric-2">boolean_metric/2</a></td><td>
 Creates boolean metric with <code>Labels</code> and <code>Value</code>.</td></tr><tr><td valign="top"><a href="#boolean_metrics-1">boolean_metrics/1</a></td><td>Equivalent to
-<a href="#boolean_metric-1"><code>lists:map(fun boolean_metric/1, Values)</code></a>.</td></tr><tr><td valign="top"><a href="#counter_metric-1">counter_metric/1</a></td><td>
+<a docgen-rel="seemfa" docgen-href="#boolean_metric/1" href="#boolean_metric-1"><code>lists:map(fun boolean_metric/1, Values)</code></a>.</td></tr><tr><td valign="top"><a href="#counter_metric-1">counter_metric/1</a></td><td>
 Equivalent to
 <a href="#counter_metric-2"><tt>counter_metric(Labels, Value)</tt></a>.</td></tr><tr><td valign="top"><a href="#counter_metric-2">counter_metric/2</a></td><td>
 Creates counter metric with <code>Labels</code> and <code>Value</code>.</td></tr><tr><td valign="top"><a href="#counter_metrics-1">counter_metrics/1</a></td><td>Equivalent to
-<a href="#counter_metric-1"><code>lists:map(fun counter_metric/1, Specs)</code></a>.</td></tr><tr><td valign="top"><a href="#create_mf-4">create_mf/4</a></td><td>
+<a docgen-rel="seemfa" docgen-href="#counter_metric/1" href="#counter_metric-1"><code>lists:map(fun counter_metric/1, Specs)</code></a>.</td></tr><tr><td valign="top"><a href="#create_mf-4">create_mf/4</a></td><td>
 Create Metric Family of <code>Type</code>, <code>Name</code> and <code>Help</code>.</td></tr><tr><td valign="top"><a href="#create_mf-5">create_mf/5</a></td><td>
 Create Metric Family of <code>Type</code>, <code>Name</code> and <code>Help</code>.</td></tr><tr><td valign="top"><a href="#gauge_metric-1">gauge_metric/1</a></td><td>
 Equivalent to
 <a href="#gauge_metric-2"><tt>gauge_metric(Labels, Value)</tt></a>.</td></tr><tr><td valign="top"><a href="#gauge_metric-2">gauge_metric/2</a></td><td>
 Creates gauge metric with <code>Labels</code> and <code>Value</code>.</td></tr><tr><td valign="top"><a href="#gauge_metrics-1">gauge_metrics/1</a></td><td>Equivalent to
-<a href="#gauge_metric-1"><code>lists:map(fun gauge_metric/1, Values)</code></a>.</td></tr><tr><td valign="top"><a href="#histogram_metric-1">histogram_metric/1</a></td><td>
+<a docgen-rel="seemfa" docgen-href="#gauge_metric/1" href="#gauge_metric-1"><code>lists:map(fun gauge_metric/1, Values)</code></a>.</td></tr><tr><td valign="top"><a href="#histogram_metric-1">histogram_metric/1</a></td><td>
 Equivalent to
 <a href="#histogram_metric-3=4">
 <tt>histogram_metric(Labels, Buckets, Count, Sum)</tt></a>.</td></tr><tr><td valign="top"><a href="#histogram_metric-3">histogram_metric/3</a></td><td>Equivalent to <a href="#histogram_metric-4"><tt>histogram_metric([], Buckets, Count, Sum)</tt></a>.</td></tr><tr><td valign="top"><a href="#histogram_metric-4">histogram_metric/4</a></td><td>
 Creates histogram metric with <code>Labels</code>, <code>Buckets</code>, <code>Count</code> and <code>Sum</code>.</td></tr><tr><td valign="top"><a href="#histogram_metrics-1">histogram_metrics/1</a></td><td>Equivalent to
-<a href="#histogram_metric-1"><code>lists:map(fun histogram_metric/1, Specs)</code></a>.</td></tr><tr><td valign="top"><a href="#label_pair-1">label_pair/1</a></td><td>
+<a docgen-rel="seemfa" docgen-href="#histogram_metric/1" href="#histogram_metric-1"><code>lists:map(fun histogram_metric/1, Specs)</code></a>.</td></tr><tr><td valign="top"><a href="#label_pair-1">label_pair/1</a></td><td>
 Creates <code>prometheus_model:</code>LabelPair'()' from {Name, Value} tuple.</td></tr><tr><td valign="top"><a href="#label_pairs-1">label_pairs/1</a></td><td>Equivalent to
-<a href="#label_pair-1"><code>lists:map(fun label_pair/1, Labels)</code></a>.</td></tr><tr><td valign="top"><a href="#metric_name-1">metric_name/1</a></td><td>
+<a docgen-rel="seemfa" docgen-href="#label_pair/1" href="#label_pair-1"><code>lists:map(fun label_pair/1, Labels)</code></a>.</td></tr><tr><td valign="top"><a href="#metric_name-1">metric_name/1</a></td><td>
 If <code>Name</code> is a list, looks for atoms and converts them to binaries.</td></tr><tr><td valign="top"><a href="#summary_metric-1">summary_metric/1</a></td><td>
 Equivalent to
 <a href="#summary_metric-3"><tt>summary_metric(Labels, Count, Sum)</tt></a>.</td></tr><tr><td valign="top"><a href="#summary_metric-2">summary_metric/2</a></td><td>Equivalent to <a href="#summary_metric-3"><tt>summary_metric([], Count, Sum)</tt></a>.</td></tr><tr><td valign="top"><a href="#summary_metric-3">summary_metric/3</a></td><td>Equivalent to <a href="#summary_metric-4"><tt>summary_metric([], Count, Sum, [])</tt></a>.</td></tr><tr><td valign="top"><a href="#summary_metric-4">summary_metric/4</a></td><td>
 Creates summary metric with <code>Labels</code>, <code>Count</code> and <code>Sum</code>.</td></tr><tr><td valign="top"><a href="#summary_metrics-1">summary_metrics/1</a></td><td>Equivalent to
-<a href="#summary_metric-1"><code>lists:map(fun summary_metric/1, Specs)</code></a>.</td></tr><tr><td valign="top"><a href="#untyped_metric-1">untyped_metric/1</a></td><td>
+<a docgen-rel="seemfa" docgen-href="#summary_metric/1" href="#summary_metric-1"><code>lists:map(fun summary_metric/1, Specs)</code></a>.</td></tr><tr><td valign="top"><a href="#untyped_metric-1">untyped_metric/1</a></td><td>
 Equivalent to
 <a href="#untyped_metric-2"><tt>untyped_metric(Labels, Value)</tt></a>.</td></tr><tr><td valign="top"><a href="#untyped_metric-2">untyped_metric/2</a></td><td>
 Creates untyped metric with <code>Labels</code> and <code>Value</code>.</td></tr><tr><td valign="top"><a href="#untyped_metrics-1">untyped_metrics/1</a></td><td>Equivalent to
-<a href="#untyped_metric-1"><code>lists:map(fun untyped_metric/1, Values)</code></a>.</td></tr></table>
+<a docgen-rel="seemfa" docgen-href="#untyped_metric/1" href="#untyped_metric-1"><code>lists:map(fun untyped_metric/1, Values)</code></a>.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -214,7 +224,7 @@ Creates untyped metric with <code>Labels</code> and <code>Value</code>.</td></tr
 ### boolean_metric/1 ###
 
 <pre><code>
-boolean_metric(Boolean) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+boolean_metric(Boolean) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Boolean = <a href="#type-pbool">pbool()</a></code></li></ul>
@@ -227,7 +237,7 @@ Equivalent to
 ### boolean_metric/2 ###
 
 <pre><code>
-boolean_metric(Labels, Value) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+boolean_metric(Labels, Value) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Labels = <a href="#type-labels">labels()</a></code></li><li><code>Value = <a href="#type-prometheus_boolean">prometheus_boolean()</a></code></li></ul>
@@ -248,7 +258,7 @@ Equivalent to
 ### counter_metric/1 ###
 
 <pre><code>
-counter_metric(Spec) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+counter_metric(Spec) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Spec = <a href="#type-counter">counter()</a></code></li></ul>
@@ -261,7 +271,7 @@ Equivalent to
 ### counter_metric/2 ###
 
 <pre><code>
-counter_metric(Labels, Value) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+counter_metric(Labels, Value) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Labels = <a href="#type-labels">labels()</a></code></li><li><code>Value = <a href="#type-value">value()</a></code></li></ul>
@@ -285,7 +295,7 @@ Equivalent to
 create_mf(Name, Help, Type, Metrics) -&gt; MetricFamily
 </code></pre>
 
-<ul class="definitions"><li><code>Name = <a href="prometheus_metric.md#type-name">prometheus_metric:name()</a></code></li><li><code>Help = <a href="prometheus_metric.md#type-help">prometheus_metric:help()</a></code></li><li><code>Type = atom()</code></li><li><code>Metrics = [<a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>] | <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a> | <a href="#type-metrics">metrics()</a></code></li><li><code>MetricFamily = <a href="prometheus_model.md#type-MetricFamily">prometheus_model:'MetricFamily'()</a></code></li></ul>
+<ul class="definitions"><li><code>Name = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_metric.html#type-name">prometheus_metric:name()</a></code></li><li><code>Help = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_metric.html#type-help">prometheus_metric:help()</a></code></li><li><code>Type = atom()</code></li><li><code>Metrics = [<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>] | <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a> | <a href="#type-metrics">metrics()</a></code></li><li><code>MetricFamily = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-MetricFamily">prometheus_model:'MetricFamily'()</a></code></li></ul>
 
 Create Metric Family of `Type`, `Name` and `Help`.
 `Collector:collect_metrics/2` callback will be called and expected to
@@ -299,7 +309,7 @@ return individual metrics list.
 create_mf(Name, Help, Type, Collector, CollectorData) -&gt; MetricFamily
 </code></pre>
 
-<ul class="definitions"><li><code>Name = <a href="prometheus_metric.md#type-name">prometheus_metric:name()</a></code></li><li><code>Help = <a href="prometheus_metric.md#type-help">prometheus_metric:help()</a></code></li><li><code>Type = atom()</code></li><li><code>Collector = <a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a></code></li><li><code>CollectorData = <a href="prometheus_collector.md#type-data">prometheus_collector:data()</a></code></li><li><code>MetricFamily = <a href="prometheus_model.md#type-MetricFamily">prometheus_model:'MetricFamily'()</a></code></li></ul>
+<ul class="definitions"><li><code>Name = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_metric.html#type-name">prometheus_metric:name()</a></code></li><li><code>Help = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_metric.html#type-help">prometheus_metric:help()</a></code></li><li><code>Type = atom()</code></li><li><code>Collector = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a></code></li><li><code>CollectorData = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-data">prometheus_collector:data()</a></code></li><li><code>MetricFamily = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-MetricFamily">prometheus_model:'MetricFamily'()</a></code></li></ul>
 
 Create Metric Family of `Type`, `Name` and `Help`.
 `Collector:collect_metrics/2` callback will be called and expected to
@@ -310,7 +320,7 @@ return individual metrics list.
 ### gauge_metric/1 ###
 
 <pre><code>
-gauge_metric(Gauge) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+gauge_metric(Gauge) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Gauge = <a href="#type-gauge">gauge()</a></code></li></ul>
@@ -323,7 +333,7 @@ Equivalent to
 ### gauge_metric/2 ###
 
 <pre><code>
-gauge_metric(Labels, Value) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+gauge_metric(Labels, Value) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Labels = <a href="#type-labels">labels()</a></code></li><li><code>Value = <a href="#type-value">value()</a></code></li></ul>
@@ -344,7 +354,7 @@ Equivalent to
 ### histogram_metric/1 ###
 
 <pre><code>
-histogram_metric(Histogram) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+histogram_metric(Histogram) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Histogram = <a href="#type-histogram">histogram()</a></code></li></ul>
@@ -369,7 +379,7 @@ Equivalent to [`histogram_metric([], Buckets, Count, Sum)`](#histogram_metric-4)
 histogram_metric(Labels, Buckets, Count, Sum) -&gt; Metric
 </code></pre>
 
-<ul class="definitions"><li><code>Labels = <a href="#type-labels">labels()</a></code></li><li><code>Buckets = [{Bound, Count}]</code></li><li><code>Bound = <a href="prometheus_buckets.md#type-bucket_bound">prometheus_buckets:bucket_bound()</a></code></li><li><code>Count = non_neg_integer()</code></li><li><code>Sum = <a href="#type-value">value()</a></code></li><li><code>Metric = <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a></code></li></ul>
+<ul class="definitions"><li><code>Labels = <a href="#type-labels">labels()</a></code></li><li><code>Buckets = [{Bound, Count}]</code></li><li><code>Bound = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_buckets.html#type-bucket_bound">prometheus_buckets:bucket_bound()</a></code></li><li><code>Count = non_neg_integer()</code></li><li><code>Sum = <a href="#type-value">value()</a></code></li><li><code>Metric = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a></code></li></ul>
 
 Creates histogram metric with `Labels`, `Buckets`, `Count` and `Sum`.
 
@@ -387,7 +397,7 @@ Equivalent to
 ### label_pair/1 ###
 
 <pre><code>
-label_pair(X1::<a href="#type-label">label()</a>) -&gt; <a href="prometheus_model.md#type-LabelPair">prometheus_model:'LabelPair'()</a>
+label_pair(X1::<a href="#type-label">label()</a>) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-LabelPair">prometheus_model:'LabelPair'()</a>
 </code></pre>
 <br />
 
@@ -397,7 +407,7 @@ Creates `prometheus_model:`LabelPair'()' from {Name, Value} tuple.
 
 ### label_pairs/1 ###
 
-`label_pairs(Labels) -> any()`
+`label_pairs(B) -> any()`
 
 Equivalent to
 [`lists:map(fun label_pair/1, Labels)`](#label_pair-1).
@@ -407,7 +417,7 @@ Equivalent to
 ### metric_name/1 ###
 
 <pre><code>
-metric_name(Name) -&gt; iolist()
+metric_name(Name) -&gt; binary()
 </code></pre>
 
 <ul class="definitions"><li><code>Name = atom() | binary() | [char() | iolist() | binary() | atom()]</code></li></ul>
@@ -420,7 +430,7 @@ Why iolists do not support atoms?
 ### summary_metric/1 ###
 
 <pre><code>
-summary_metric(Summary) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+summary_metric(Summary) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Summary = <a href="#type-summary">summary()</a></code></li></ul>
@@ -449,7 +459,7 @@ Equivalent to [`summary_metric([], Count, Sum, [])`](#summary_metric-4).
 ### summary_metric/4 ###
 
 <pre><code>
-summary_metric(Labels, Count, Sum, Quantiles) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+summary_metric(Labels, Count, Sum, Quantiles) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Labels = <a href="#type-labels">labels()</a></code></li><li><code>Count = non_neg_integer()</code></li><li><code>Sum = <a href="#type-value">value()</a></code></li><li><code>Quantiles = list()</code></li></ul>
@@ -470,7 +480,7 @@ Equivalent to
 ### untyped_metric/1 ###
 
 <pre><code>
-untyped_metric(Untyped) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+untyped_metric(Untyped) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Untyped = <a href="#type-untyped">untyped()</a></code></li></ul>
@@ -483,7 +493,7 @@ Equivalent to
 ### untyped_metric/2 ###
 
 <pre><code>
-untyped_metric(Labels, Value) -&gt; <a href="prometheus_model.md#type-Metric">prometheus_model:'Metric'()</a>
+untyped_metric(Labels, Value) -&gt; <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_model.html#type-Metric">prometheus_model:'Metric'()</a>
 </code></pre>
 
 <ul class="definitions"><li><code>Labels = <a href="#type-labels">labels()</a></code></li><li><code>Value = <a href="#type-value">value()</a></code></li></ul>

--- a/doc/prometheus_protobuf_format.md
+++ b/doc/prometheus_protobuf_format.md
@@ -54,7 +54,7 @@ Formats `default` registry using protocol buffer format.
 ### format/1 ###
 
 <pre><code>
-format(Registry::<a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a>) -&gt; binary()
+format(Registry::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a>) -&gt; binary()
 </code></pre>
 <br />
 

--- a/doc/prometheus_registry.md
+++ b/doc/prometheus_registry.md
@@ -29,7 +29,7 @@ batch jobs.
 
 
 <pre><code>
-collect_callback() = fun((<a href="#type-registry">registry()</a>, <a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a>) -&gt; any())
+collect_callback() = fun((<a href="#type-registry">registry()</a>, <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a>) -&gt; any())
 </code></pre>
 
 
@@ -74,7 +74,7 @@ Equivalent to [`clear(default)`](#clear-1).
 ### clear/1 ###
 
 <pre><code>
-clear(Registry::<a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a>) -&gt; ok
+clear(Registry::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a>) -&gt; ok
 </code></pre>
 <br />
 
@@ -88,7 +88,7 @@ Unregisters all collectors.
 collect(Registry, Callback) -&gt; ok
 </code></pre>
 
-<ul class="definitions"><li><code>Registry = <a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a></code></li><li><code>Callback = <a href="#type-collect_callback">collect_callback()</a></code></li></ul>
+<ul class="definitions"><li><code>Registry = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a></code></li><li><code>Callback = <a href="#type-collect_callback">collect_callback()</a></code></li></ul>
 
 Calls `Callback` for each collector with two arguments:
 `Registry` and `Collector`.
@@ -101,7 +101,7 @@ Calls `Callback` for each collector with two arguments:
 collector_registeredp(Collector) -&gt; boolean()
 </code></pre>
 
-<ul class="definitions"><li><code>Collector = <a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a></code></li></ul>
+<ul class="definitions"><li><code>Collector = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a></code></li></ul>
 
 Equivalent to [`collector_registeredp(default, Collector)`](#collector_registeredp-2).
 
@@ -113,7 +113,7 @@ Equivalent to [`collector_registeredp(default, Collector)`](#collector_registere
 collector_registeredp(Registry, Collector) -&gt; boolean()
 </code></pre>
 
-<ul class="definitions"><li><code>Registry = <a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a></code></li><li><code>Collector = <a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a></code></li></ul>
+<ul class="definitions"><li><code>Registry = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a></code></li><li><code>Collector = <a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a></code></li></ul>
 
 Checks whether `Collector` is registered.
 
@@ -122,7 +122,7 @@ Checks whether `Collector` is registered.
 ### collectors/1 ###
 
 <pre><code>
-collectors(Registry::<a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a>) -&gt; [Collector::<a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a>]
+collectors(Registry::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a>) -&gt; [Collector::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a>]
 </code></pre>
 <br />
 
@@ -133,7 +133,7 @@ Returns collectors registered in `Registry`.
 ### deregister_collector/1 ###
 
 <pre><code>
-deregister_collector(Collector::<a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a>) -&gt; ok
+deregister_collector(Collector::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a>) -&gt; ok
 </code></pre>
 <br />
 
@@ -144,7 +144,7 @@ Equivalent to [`deregister_collector(default, Collector)`](#deregister_collector
 ### deregister_collector/2 ###
 
 <pre><code>
-deregister_collector(Registry::<a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a>, Collector::<a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a>) -&gt; ok
+deregister_collector(Registry::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a>, Collector::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a>) -&gt; ok
 </code></pre>
 <br />
 
@@ -171,7 +171,7 @@ atoms) and returns atom or false. This operation is O(n).
 ### register_collector/1 ###
 
 <pre><code>
-register_collector(Collector::<a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a>) -&gt; ok
+register_collector(Collector::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a>) -&gt; ok
 </code></pre>
 <br />
 
@@ -182,7 +182,7 @@ Equivalent to [`register_collector(default, Collector)`](#register_collector-2).
 ### register_collector/2 ###
 
 <pre><code>
-register_collector(Registry::<a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a>, Collector::<a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a>) -&gt; ok
+register_collector(Registry::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a>, Collector::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a>) -&gt; ok
 </code></pre>
 <br />
 
@@ -193,7 +193,7 @@ Register a collector.
 ### register_collectors/1 ###
 
 <pre><code>
-register_collectors(Collectors::[<a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a>]) -&gt; ok
+register_collectors(Collectors::[<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a>]) -&gt; ok
 </code></pre>
 <br />
 
@@ -204,7 +204,7 @@ Equivalent to [`register_collectors(default, Collectors)`](#register_collectors-
 ### register_collectors/2 ###
 
 <pre><code>
-register_collectors(Registry::<a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a>, Collectors::[<a href="prometheus_collector.md#type-collector">prometheus_collector:collector()</a>]) -&gt; ok
+register_collectors(Registry::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a>, Collectors::[<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_collector.html#type-collector">prometheus_collector:collector()</a>]) -&gt; ok
 </code></pre>
 <br />
 

--- a/doc/prometheus_text_format.md
+++ b/doc/prometheus_text_format.md
@@ -75,7 +75,7 @@ Formats `default` registry using the latest text format.
 ### format/1 ###
 
 <pre><code>
-format(Registry::<a href="prometheus_registry.md#type-registry">prometheus_registry:registry()</a>) -&gt; binary()
+format(Registry::<a href="http://www.erlang.org/edoc/doc/prometheus/doc/prometheus_registry.html#type-registry">prometheus_registry:registry()</a>) -&gt; binary()
 </code></pre>
 <br />
 

--- a/doc/prometheus_time.md
+++ b/doc/prometheus_time.md
@@ -17,7 +17,7 @@ so called native time units. Native time units are meaningless
 and have to be converted to seconds (or other units)
 using `erlang:convert_time_unit`.
 However as `erlang:convert_time_unit` documentation
-[warns](http://erlang.org/doc/man/erlang.html#convert_time_unit-3):
+[warns](http://www.erlang.org/doc/man/erlang.html#convert_time_unit-3):
 
 ```
   You may lose accuracy and precision when converting between  time units.

--- a/doc/prometheus_vm_memory_collector.md
+++ b/doc/prometheus_vm_memory_collector.md
@@ -7,7 +7,7 @@ Collects information about memory dynamically allocated
 by the Erlang emulator using
 [
 erlang:memory/0
-](http://erlang.org/doc/man/erlang.md#memory-0), also provides basic (D)ETS statistics.
+](http://www.erlang.org/doc/man/erlang.html#memory-0), also provides basic (D)ETS statistics.
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 

--- a/doc/prometheus_vm_msacc_collector.md
+++ b/doc/prometheus_vm_msacc_collector.md
@@ -6,7 +6,7 @@
 Collects microstate accounting metrics using
 [
 erlang:statistics(microstate_accounting)
-](http://erlang.org/doc/man/erlang.md#statistics_microstate_accounting).
+](http://www.erlang.org/doc/man/erlang.html#statistics_microstate_accounting).
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 
@@ -104,7 +104,7 @@ Metrics exported by this collector can be configured via
 Options are the same as MSAcc_Thread_State return type from
 [
 erlang:statistics(microstate_accounting)
-](http://erlang.org/doc/man/erlang.md#statistics_microstate_accounting) with `_seconds_total` as the suffix:
+](http://www.erlang.org/doc/man/erlang.html#statistics_microstate_accounting) with `_seconds_total` as the suffix:
 
 * `aux_seconds_total` for `erlang_vm_msacc_aux_seconds_total`.
 

--- a/doc/prometheus_vm_statistics_collector.md
+++ b/doc/prometheus_vm_statistics_collector.md
@@ -6,7 +6,7 @@
 Collects Erlang VM metrics using
 [
 erlang:statistics/1
-](http://erlang.org/doc/man/erlang.md#statistics-1).
+](http://www.erlang.org/doc/man/erlang.html#statistics-1).
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 
@@ -80,7 +80,7 @@ Metrics exported by this collector can be configured via
 Options are the same as Item parameter values for
 [
 erlang:statistics/1
-](http://erlang.org/doc/man/erlang.md#statistics-1):
+](http://www.erlang.org/doc/man/erlang.html#statistics-1):
 
 * `context_switches` for `erlang_vm_statistics_context_switches`;
 

--- a/doc/prometheus_vm_system_info_collector.md
+++ b/doc/prometheus_vm_system_info_collector.md
@@ -6,7 +6,7 @@
 Collects Erlang VM metrics using
 [
 erlang:system_info/1
-](http://erlang.org/doc/man/erlang.md#system_info-1).
+](http://www.erlang.org/doc/man/erlang.html#system_info-1).
 
 __Behaviours:__ [`prometheus_collector`](prometheus_collector.md).
 
@@ -116,7 +116,7 @@ Metrics exported by this collector can be configured via
 Options are the same as Item parameter values for
 [
 erlang:system_info/1
-](http://erlang.org/doc/man/erlang.md#system_info-1):
+](http://www.erlang.org/doc/man/erlang.html#system_info-1):
 
 * `ets_limit` for `erlang_vm_ets_limit`.
 

--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,7 @@
 {xref_checks, [undefined_function_calls,undefined_functions,locals_not_used,
                deprecated_function_calls,deprecated_functions]}.
 
-{profiles, [{docs, [{deps, [{edown, "0.8.1"}]},
+{profiles, [{docs, [{deps, [{edown, "0.8.4"}]},
                     {edoc_opts,
                      [{doclet, edown_doclet},
                       {dir, "doc"},

--- a/src/collectors/mnesia/prometheus_mnesia_collector.erl
+++ b/src/collectors/mnesia/prometheus_mnesia_collector.erl
@@ -1,6 +1,6 @@
 %% @doc
 %% Collects Mnesia metrics mainly using
-%% <a href="http://erlang.org/doc/man/mnesia.html#system_info-1">
+%% <a href="http://www.erlang.org/doc/man/mnesia.html#system_info-1">
 %%   mnesia:system_info/1
 %% </a>.
 %%

--- a/src/collectors/vm/prometheus_vm_memory_collector.erl
+++ b/src/collectors/vm/prometheus_vm_memory_collector.erl
@@ -1,7 +1,7 @@
 %% @doc
 %% Collects information about memory dynamically allocated
 %% by the Erlang emulator using
-%% <a href="http://erlang.org/doc/man/erlang.html#memory-0">
+%% <a href="http://www.erlang.org/doc/man/erlang.html#memory-0">
 %%   erlang:memory/0
 %% </a>, also provides basic (D)ETS statistics.
 %%

--- a/src/collectors/vm/prometheus_vm_msacc_collector.erl
+++ b/src/collectors/vm/prometheus_vm_msacc_collector.erl
@@ -1,6 +1,6 @@
 %% @doc
 %% Collects microstate accounting metrics using
-%% <a href="http://erlang.org/doc/man/erlang.html#statistics_microstate_accounting">
+%% <a href="http://www.erlang.org/doc/man/erlang.html#statistics_microstate_accounting">
 %%   erlang:statistics(microstate_accounting)
 %% </a>.
 %%
@@ -106,7 +106,7 @@
 %% `vm_msacc_collector_metrics' key of `prometheus' app environment.
 %%
 %% Options are the same as MSAcc_Thread_State return type from
-%% <a href="http://erlang.org/doc/man/erlang.html#statistics_microstate_accounting">
+%% <a href="http://www.erlang.org/doc/man/erlang.html#statistics_microstate_accounting">
 %%   erlang:statistics(microstate_accounting)
 %% </a> with `_seconds_total' as the suffix:
 %% <ul>

--- a/src/collectors/vm/prometheus_vm_statistics_collector.erl
+++ b/src/collectors/vm/prometheus_vm_statistics_collector.erl
@@ -1,6 +1,6 @@
 %% @doc
 %% Collects Erlang VM metrics using
-%% <a href="http://erlang.org/doc/man/erlang.html#statistics-1">
+%% <a href="http://www.erlang.org/doc/man/erlang.html#statistics-1">
 %%   erlang:statistics/1
 %% </a>.
 %%
@@ -78,7 +78,7 @@
 %% `vm_statistics_collector_metrics' key of `prometheus' app environment.
 %%
 %% Options are the same as Item parameter values for
-%% <a href="http://erlang.org/doc/man/erlang.html#statistics-1">
+%% <a href="http://www.erlang.org/doc/man/erlang.html#statistics-1">
 %%   erlang:statistics/1
 %% </a>:
 %% <ul>

--- a/src/collectors/vm/prometheus_vm_system_info_collector.erl
+++ b/src/collectors/vm/prometheus_vm_system_info_collector.erl
@@ -1,6 +1,6 @@
 %% @doc
 %% Collects Erlang VM metrics using
-%% <a href="http://erlang.org/doc/man/erlang.html#system_info-1">
+%% <a href="http://www.erlang.org/doc/man/erlang.html#system_info-1">
 %%   erlang:system_info/1
 %% </a>.
 %%
@@ -123,7 +123,7 @@
 %% `vm_system_info_collector_metrics' key of `prometheus' app environment.
 %%
 %% Options are the same as Item parameter values for
-%% <a href="http://erlang.org/doc/man/erlang.html#system_info-1">
+%% <a href="http://www.erlang.org/doc/man/erlang.html#system_info-1">
 %%   erlang:system_info/1
 %% </a>:
 %% <ul>

--- a/src/contrib/prometheus_mnesia.erl
+++ b/src/contrib/prometheus_mnesia.erl
@@ -35,7 +35,7 @@ table_disk_size(Table) ->
 %% - .LOGTMP - disc copies log
 %%
 %% More on Mnesia files can be found in
-%% <a href="http://erlang.org/doc/apps/mnesia/Mnesia_chap7.html">
+%% <a href="http://www.erlang.org/doc/apps/mnesia/Mnesia_chap7.html">
 %%   Mnesia System Information chapter
 %% </a> of Mnesia User's Guide
 %% @end

--- a/src/metrics/prometheus_counter.erl
+++ b/src/metrics/prometheus_counter.erl
@@ -24,7 +24,7 @@
 %% the difference is that {@link new/1} will raise
 %% {:mf_already_exists, {Registry, Name}, Message} error if counter with
 %% the same `Registry', `Name' and `Labels' combination already exists.
-%% Both accept `Spec' [proplist](http://erlang.org/doc/man/proplists.html)
+%% Both accept `Spec' [proplist](http://www.erlang.org/doc/man/proplists.html)
 %% with the same set of keys:
 %%
 %%  - `Registry' - optional, default is `default';

--- a/src/prometheus_time.erl
+++ b/src/prometheus_time.erl
@@ -8,7 +8,7 @@
 %% and have to be converted to seconds (or other units)
 %% using `erlang:convert_time_unit'.
 %% However as `erlang:convert_time_unit' documentation
-%% [warns](http://erlang.org/doc/man/erlang.html#convert_time_unit-3):
+%% [warns](http://www.erlang.org/doc/man/erlang.html#convert_time_unit-3):
 %%
 %% ```
 %% You may lose accuracy and precision when converting between  time units.


### PR DESCRIPTION
Please review and merge https://github.com/deadtrickster/prometheus.erl/pull/141 in advance.

## Overview

Some links are suffixed by edown
e.g., `http://erlang.org/doc/man/mnesia.md#system_info-1`

We should use `http://www.erlang.org/doc/man/` instead of `http://erlang.org/doc/man/` because the edown recognizes the former. Otherwise it replaces `.html` to `.md`.
https://github.com/uwiger/edown/blob/754be25f71a04099c83f3ffdff268e70beeb0021/src/edown_lib.erl#L44-L52