### PR TITLE
Weighted histogram

### DIFF
--- a/src/metrics/prometheus_histogram.erl
+++ b/src/metrics/prometheus_histogram.erl
@@ -31,10 +31,11 @@
 %% </pre>
 %%
 %% The `prometheus_histogram:observe_n/3,4,5' adds limited support for the
-%% weighted histograms. It accepts the extra argument "Weight" which is limited
-%% to integer numbers to fit existing bucket counters data type. It may be, for
-%% example, the number of time ticks when the recent value was observed,
-%% allowing for better accuracy when measurements are irregular.
+%% "weighted" histograms. It accepts the extra integer argument "Count" to
+%% update the number of observations in the bucket by adding that number.
+%% This allows for better accuracy in the case of irregular measurements,
+%% assuming that the "Count" conveys the observation time interval (for
+%% example, the number of time ticks when the recent value was observed).
 %%
 %% @end
 
@@ -205,46 +206,46 @@ observe(Registry, Name, LabelValues, Value) when is_number(Value) ->
 observe(_Registry, _Name, _LabelValues, Value) ->
   erlang:error({invalid_value, Value, "observe accepts only numbers"}).
 
-%% @equiv observe_n(default, Name, [], Value, Weight)
-observe_n(Name, Value, Weight) ->
-  observe_n(default, Name, [], Value, Weight).
+%% @equiv observe_n(default, Name, [], Value, Count)
+observe_n(Name, Value, Count) ->
+  observe_n(default, Name, [], Value, Count).
 
-%% @equiv observe_n(default, Name, LabelValues, Value, Weight)
-observe_n(Name, LabelValues, Value, Weight) ->
-  observe_n(default, Name, LabelValues, Value, Weight).
+%% @equiv observe_n(default, Name, LabelValues, Value, Count)
+observe_n(Name, LabelValues, Value, Count) ->
+  observe_n(default, Name, LabelValues, Value, Count).
 
-%% @doc Observes the given `Value' with weight `Weight'.
+%% @doc Observes the given `Value' `Count' times.
 %%
 %% Raises `{invalid_value, Value, Message}' if `Value' isn't a number.<br/>
-%% Raises `{invalid_weight, Weight, Message}' if `Weight' isn't integer.<br/>
+%% Raises `{invalid_count, Count, Message}' if `Count' isn't integer.<br/>
 %% Raises `{unknown_metric, Registry, Name}' error if histogram with named
 %% `Name' can't be found in `Registry'.<br/>
 %% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
 %% mismatch.
 %% @end
-observe_n(Registry, Name, LabelValues, Value, Weight) when is_integer(Value), is_integer(Weight) ->
+observe_n(Registry, Name, LabelValues, Value, Count) when is_integer(Value), is_integer(Count) ->
   Key = key(Registry, Name, LabelValues),
   case ets:lookup(?TABLE, Key) of
     [Metric] ->
       BucketPosition = calculate_histogram_bucket_position(Metric, Value),
       ets:update_counter(?TABLE, Key,
-                         [{?ISUM_POS, Value * Weight},
-                          {?BUCKETS_START + BucketPosition, Weight}]);
+                         [{?ISUM_POS, Value * Count},
+                          {?BUCKETS_START + BucketPosition, Count}]);
     [] ->
-      insert_metric(Registry, Name, LabelValues, Value, Weight, fun observe_n/5)
+      insert_metric(Registry, Name, LabelValues, Value, Count, fun observe_n/5)
   end,
   ok;
-observe_n(Registry, Name, LabelValues, Value, Weight) when is_number(Value), is_integer(Weight) ->
+observe_n(Registry, Name, LabelValues, Value, Count) when is_number(Value), is_integer(Count) ->
   Key = key(Registry, Name, LabelValues),
   case ets:lookup(?TABLE, Key) of
     [Metric] ->
-      fobserve_impl(Key, Metric, Value, Weight);
+      fobserve_impl(Key, Metric, Value, Count);
     [] ->
-      insert_metric(Registry, Name, LabelValues, Value, Weight, fun observe_n/5)
+      insert_metric(Registry, Name, LabelValues, Value, Count, fun observe_n/5)
   end;
-observe_n(_Registry, _Name, _LabelValues, Value, Weight) when is_number(Value) ->
-  erlang:error({invalid_weight, Weight, "observe_n accepts only integer weights"});
-observe_n(_Registry, _Name, _LabelValues, Value, _Weight) ->
+observe_n(_Registry, _Name, _LabelValues, Value, Count) when is_number(Value) ->
+  erlang:error({invalid_count, Count, "observe_n accepts only integer counts"});
+observe_n(_Registry, _Name, _LabelValues, Value, _Count) ->
   erlang:error({invalid_value, Value, "observe_n accepts only number values"}).
 
 %% @private
@@ -461,17 +462,17 @@ insert_metric(Registry, Name, LabelValues, Value, CB) ->
   insert_placeholders(Registry, Name, LabelValues),
   CB(Registry, Name, LabelValues, Value).
 
-insert_metric(Registry, Name, LabelValues, Value, Weight, CB) ->
+insert_metric(Registry, Name, LabelValues, Value, Count, CB) ->
   insert_placeholders(Registry, Name, LabelValues),
-  CB(Registry, Name, LabelValues, Value, Weight).
+  CB(Registry, Name, LabelValues, Value, Count).
 
-fobserve_impl(Key, Metric, Value, Weight) ->
+fobserve_impl(Key, Metric, Value, Count) ->
   Buckets = metric_buckets(Metric),
   BucketPos = calculate_histogram_bucket_position(Metric, Value),
-  fobserve_impl(Key, Buckets, BucketPos, Value, Weight).
+  fobserve_impl(Key, Buckets, BucketPos, Value, Count).
 
-fobserve_impl(Key, Buckets, BucketPos, Value, Weight) ->
-  ets:select_replace(?TABLE, generate_select_replace(Key, Buckets, BucketPos, Value, Weight)).
+fobserve_impl(Key, Buckets, BucketPos, Value, Count) ->
+  ets:select_replace(?TABLE, generate_select_replace(Key, Buckets, BucketPos, Value, Count)).
 
 insert_placeholders(Registry, Name, LabelValues) ->
   MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
@@ -490,13 +491,13 @@ calculate_histogram_bucket_position(Metric, Value) ->
   Buckets = metric_buckets(Metric),
   prometheus_buckets:position(Buckets, Value).
 
-generate_select_replace(Key, Bounds, BucketPos, Value, Weight) ->
+generate_select_replace(Key, Bounds, BucketPos, Value, Count) ->
   BoundPlaceholders = gen_query_bound_placeholders(Bounds),
   HistMatch = list_to_tuple([Key, '$2', '$3', '$4'] ++ BoundPlaceholders),
   BucketUpdate = lists:sublist(BoundPlaceholders, BucketPos)
-    ++ [{'+', gen_query_placeholder(?BUCKETS_START + BucketPos), Weight}]
+    ++ [{'+', gen_query_placeholder(?BUCKETS_START + BucketPos), Count}]
     ++ lists:nthtail(BucketPos + 1, BoundPlaceholders),
-  HistUpdate = list_to_tuple([{Key}, '$2', '$3', {'+', '$4', Value * Weight}] ++ BucketUpdate),
+  HistUpdate = list_to_tuple([{Key}, '$2', '$3', {'+', '$4', Value * Count}] ++ BucketUpdate),
   [{HistMatch,
     [],
     [{HistUpdate}]}].

--- a/test/eunit/metric/prometheus_histogram_tests.erl
+++ b/test/eunit/metric/prometheus_histogram_tests.erl
@@ -107,7 +107,7 @@ test_errors(_) ->
                  prometheus_histogram:observe(request_duration, "qwe")),
    ?_assertError({invalid_value, "qwe", "observe_n accepts only number values"},
                  prometheus_histogram:observe_n(request_duration, "qwe", 3)),
-   ?_assertError({invalid_weight, "qwe", "observe_n accepts only integer weights"},
+   ?_assertError({invalid_count, "qwe", "observe_n accepts only integer counts"},
                  prometheus_histogram:observe_n(request_duration, 300, "qwe")),
    ?_assertError({invalid_value, "qwe", "observe_duration accepts only functions"},
                  prometheus_histogram:observe_duration(pool_size, "qwe"))


### PR DESCRIPTION
The `prometheus_histogram:observe_n/3,4,5` adds limited support for the weighted histograms. It accepts the extra argument "Weight" which is limited to integer numbers to fit existing bucket counters data type. It may be, for example, the number of time ticks when the recent value was observed, allowing for better accuracy when measurements are irregular.

In general, the weight could be any number, but this is difficult to implement since the overall Prometheus histogram model is based on the bucket counters concept, where the counters are expected to be non-negative integers. That's why the new function is limited to integer weights only, which is still useful in many applications.
