### PR TITLE
Move export prometheus_text_format:escape_label_value outside of TEST def

### DIFF
--- a/src/formats/prometheus_text_format.erl
+++ b/src/formats/prometheus_text_format.erl
@@ -77,7 +77,8 @@ format(Registry) ->
   ok = file:close(Fd),
   Str.
 
--spec escape_label_value(binary() | iolist() | undefined) -> binary().
+-spec escape_label_value(binary() | iolist()) -> binary()
+                      ; (undefined) -> no_return().
 %% @doc
 %% Escapes the backslash (\), double-quote ("), and line feed (\n) characters
 %% @end

--- a/src/formats/prometheus_text_format.erl
+++ b/src/formats/prometheus_text_format.erl
@@ -22,11 +22,12 @@
 -export([content_type/0,
          format/0,
          format/1,
-         render_labels/1]).
+         render_labels/1,
+         escape_label_value/1
+        ]).
 
 -ifdef(TEST).
 -export([escape_metric_help/1,
-         escape_label_value/1,
          emit_mf_prologue/2,
          emit_mf_metrics/2
         ]).
@@ -75,6 +76,15 @@ format(Registry) ->
   {ok, Str} = file:pread(Fd, 0, Size),
   ok = file:close(Fd),
   Str.
+
+-spec escape_label_value(binary() | iolist() | undefined) -> binary().
+%% @doc
+%% Escapes the backslash (\), double-quote ("), and line feed (\n) characters
+%% @end
+escape_label_value(LValue) when is_list(LValue); is_binary(LValue) ->
+  escape_string(fun escape_label_char/1, LValue);
+escape_label_value(Value) ->
+  erlang:error({wtf, Value}).
 
 %%====================================================================
 %% Private Parts
@@ -226,13 +236,6 @@ bound_to_label_value(Bound) when is_float(Bound) ->
   float_to_list(Bound);
 bound_to_label_value(infinity) ->
   "+Inf".
-
--spec escape_label_value(binary() | iolist() | undefined) -> binary().
-%% @private
-escape_label_value(LValue) when is_list(LValue); is_binary(LValue) ->
-  escape_string(fun escape_label_char/1, LValue);
-escape_label_value(Value) ->
-  erlang:error({wtf, Value}).
 
 %% @private
 escape_label_char($\\ = X) ->


### PR DESCRIPTION
`prometheus_text_format:escape_label_value` is a useful helper function that users can benefit from using without having to duplicate the function in their code.

Namely, it can be used to escape prometheus core metric label values -- based on issue [rabbitmq/rabbitmq-server#9648](https://github.com/rabbitmq/rabbitmq-server/issues/9648) and relevant PR/review from [rabbitmq/rabbitmq-server#9656 ](https://github.com/rabbitmq/rabbitmq-server/pull/9656#discussion_r1355756241)