### PR TITLE
Optimise text_format:escape_label_value

### DIFF
--- a/test/eunit/format/prometheus_text_format_tests.erl
+++ b/test/eunit/format/prometheus_text_format_tests.erl
@@ -28,6 +28,10 @@ escape_label_value_test()->
   ?assertEqual(<<"qwe\\\\qwe\\nq\\\"we\\\"qwe">>,
                prometheus_text_format:escape_label_value("qwe\\qwe\nq\"we\"qwe")).
 
+escape_label_value_no_special_char_test() ->
+    LabelBin = <<"qweqweqwe">>,
+    ?assert(erts_debug:same(LabelBin, prometheus_text_format:escape_label_value(LabelBin))).
+
 prometheus_format_test_() ->
   {foreach,
    fun prometheus_eunit_common:start/0,


### PR DESCRIPTION
Don't create a new binary if there is no special character to escape.

This PR is based on https://github.com/deadtrickster/prometheus.erl/pull/158 to preserve attribution of the author of that change.