### PR TITLE
Optimize text format scrape hot path

### DIFF
--- a/src/formats/prometheus_text_format.erl
+++ b/src/formats/prometheus_text_format.erl
@@ -35,7 +35,7 @@ http_request_duration_milliseconds_sum{method=\"post\"} 4350
 -include("prometheus_model.hrl").
 
 -behaviour(prometheus_format).
--compile({inline, [render_label_pair/1]}).
+-compile({inline, [render_label_pair/1, render_series/4, render_value/2]}).
 
 ?DOC("""
 Returns content type of the latest \[text format](https://bit.ly/2cxSuJP).

--- a/src/metrics/prometheus_boolean.erl
+++ b/src/metrics/prometheus_boolean.erl
@@ -326,14 +326,16 @@ deregister_cleanup(Registry) ->
 -spec collect_mf(prometheus_registry:registry(), prometheus_collector:collect_mf_callback()) -> ok.
 collect_mf(Registry, Callback) ->
     [
-        Callback(create_boolean(Name, Help, {CLabels, Labels, Registry}))
-     || [Name, {Labels, Help}, CLabels, _, _] <- prometheus_metric:metrics(?TABLE, Registry)
+        Callback(create_boolean(NameBin, HelpBin, {CLabels, Labels, Registry, Name}))
+     || [Name, {Labels, HelpBin, NameBin}, CLabels, _, _] <- prometheus_metric:metrics(
+            ?TABLE, Registry
+        )
     ],
     ok.
 
 ?DOC(false).
 -spec collect_metrics(prometheus_metric:name(), tuple()) -> [prometheus_model:'Metric'()].
-collect_metrics(Name, {CLabels, Labels, Registry}) ->
+collect_metrics(_NameBin, {CLabels, Labels, Registry, Name}) ->
     [
         prometheus_model_helpers:boolean_metric(
             CLabels ++ lists:zip(Labels, LabelValues), Value

--- a/src/metrics/prometheus_counter.erl
+++ b/src/metrics/prometheus_counter.erl
@@ -336,15 +336,17 @@ deregister_cleanup(Registry) ->
 -spec collect_mf(prometheus_registry:registry(), prometheus_collector:collect_mf_callback()) -> ok.
 collect_mf(Registry, Callback) ->
     [
-        Callback(create_counter(Name, Help, {CLabels, Labels, Registry}))
-     || [Name, {Labels, Help}, CLabels, _, _] <- prometheus_metric:metrics(?TABLE, Registry)
+        Callback(create_counter(NameBin, HelpBin, {CLabels, Labels, Registry, Name}))
+     || [Name, {Labels, HelpBin, NameBin}, CLabels, _, _] <- prometheus_metric:metrics(
+            ?TABLE, Registry
+        )
     ],
     ok.
 
 ?DOC(false).
 -spec collect_metrics(prometheus_metric:name(), tuple()) ->
     [prometheus_model:'Metric'()].
-collect_metrics(Name, {CLabels, Labels, Registry}) ->
+collect_metrics(_NameBin, {CLabels, Labels, Registry, Name}) ->
     MFValues = load_all_values(Registry, Name),
     LabelValues = reduce_label_values(MFValues),
     Fun = fun(VLabels, Value) ->

--- a/src/metrics/prometheus_gauge.erl
+++ b/src/metrics/prometheus_gauge.erl
@@ -529,15 +529,17 @@ deregister_cleanup(Registry) ->
 -spec collect_mf(prometheus_registry:registry(), prometheus_collector:collect_mf_callback()) -> ok.
 collect_mf(Registry, Callback) ->
     [
-        Callback(create_gauge(Name, Help, {CLabels, Labels, Registry, DU}))
-     || [Name, {Labels, Help}, CLabels, DU, _] <- prometheus_metric:metrics(?TABLE, Registry)
+        Callback(create_gauge(NameBin, HelpBin, {CLabels, Labels, Registry, DU, Name}))
+     || [Name, {Labels, HelpBin, NameBin}, CLabels, DU, _] <- prometheus_metric:metrics(
+            ?TABLE, Registry
+        )
     ],
     ok.
 
 ?DOC(false).
 -spec collect_metrics(prometheus_metric:name(), tuple()) ->
     [prometheus_model:'Metric'()].
-collect_metrics(Name, {CLabels, Labels, Registry, DU}) ->
+collect_metrics(_NameBin, {CLabels, Labels, Registry, DU, Name}) ->
     [
         prometheus_model_helpers:gauge_metric(
             CLabels ++ lists:zip(Labels, LabelValues),

--- a/src/metrics/prometheus_histogram.erl
+++ b/src/metrics/prometheus_histogram.erl
@@ -495,15 +495,17 @@ deregister_cleanup(Registry) ->
 -spec collect_mf(prometheus_registry:registry(), prometheus_collector:collect_mf_callback()) -> ok.
 collect_mf(Registry, Callback) ->
     [
-        Callback(create_histogram(Name, Help, {CLabels, Labels, Registry, DU, Buckets}))
-     || [Name, {Labels, Help}, CLabels, DU, Buckets] <- prometheus_metric:metrics(?TABLE, Registry)
+        Callback(create_histogram(NameBin, HelpBin, {CLabels, Labels, Registry, DU, Buckets, Name}))
+     || [Name, {Labels, HelpBin, NameBin}, CLabels, DU, Buckets] <- prometheus_metric:metrics(
+            ?TABLE, Registry
+        )
     ],
     ok.
 
 ?DOC(false).
 -spec collect_metrics(prometheus_metric:name(), tuple()) ->
     [prometheus_model:'Metric'()].
-collect_metrics(Name, {CLabels, Labels, Registry, DU, Bounds}) ->
+collect_metrics(_NameBin, {CLabels, Labels, Registry, DU, Bounds, Name}) ->
     MFValues = load_all_values(Registry, Name, Bounds),
     LabelValuesMap = reduce_label_values(MFValues),
     Fun = fun(LabelValues, Stat, L) ->

--- a/src/metrics/prometheus_quantile_summary.erl
+++ b/src/metrics/prometheus_quantile_summary.erl
@@ -381,15 +381,15 @@ deregister_cleanup(Registry) ->
 collect_mf(Registry, Callback) ->
     Metrics = prometheus_metric:metrics(?TABLE, Registry),
     [
-        Callback(create_summary(Name, Help, {CLabels, Labels, Registry, DU, Data}))
-     || [Name, {Labels, Help}, CLabels, DU, Data] <- Metrics
+        Callback(create_summary(NameBin, HelpBin, {CLabels, Labels, Registry, DU, Data, Name}))
+     || [Name, {Labels, HelpBin, NameBin}, CLabels, DU, Data] <- Metrics
     ],
     ok.
 
 ?DOC(false).
 -spec collect_metrics(prometheus_metric:name(), tuple()) ->
     [prometheus_model:'Metric'()].
-collect_metrics(Name, {CLabels, Labels, Registry, _DU, _Configuration}) ->
+collect_metrics(_NameBin, {CLabels, Labels, Registry, _DU, _Configuration, Name}) ->
     Fun = fun model_summary_metric/6,
     loop_through_keys(Name, Fun, CLabels, Labels, Registry).
 

--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -376,15 +376,17 @@ deregister_cleanup(Registry) ->
 -spec collect_mf(prometheus_registry:registry(), prometheus_collector:collect_mf_callback()) -> ok.
 collect_mf(Registry, Callback) ->
     [
-        Callback(create_summary(Name, Help, {CLabels, Labels, Registry, DU}))
-     || [Name, {Labels, Help}, CLabels, DU, _] <- prometheus_metric:metrics(?TABLE, Registry)
+        Callback(create_summary(NameBin, HelpBin, {CLabels, Labels, Registry, DU, Name}))
+     || [Name, {Labels, HelpBin, NameBin}, CLabels, DU, _] <- prometheus_metric:metrics(
+            ?TABLE, Registry
+        )
     ],
     ok.
 
 ?DOC(false).
 -spec collect_metrics(prometheus_metric:name(), tuple()) ->
     [prometheus_model:'Metric'()].
-collect_metrics(Name, {CLabels, Labels, Registry, DU}) ->
+collect_metrics(_NameBin, {CLabels, Labels, Registry, DU, Name}) ->
     MFValues = load_all_values(Registry, Name),
     ReducedMap = lists:foldl(
         fun([L, C, IS, FS], ResAcc) ->

--- a/src/model/prometheus_model_helpers.erl
+++ b/src/model/prometheus_model_helpers.erl
@@ -45,7 +45,6 @@ Probably will be used with `m:prometheus_collector`.
 
 -ifdef(TEST).
 -export([
-    filter_undefined_metrics/1,
     ensure_mf_type/1,
     ensure_binary_or_string/1
 ]).
@@ -106,12 +105,11 @@ create_mf(Name, Help, Type, [First | _] = Metrics0) when
     is_list(Metrics0), is_record(First, 'Metric')
 ->
     %% Fast path: metrics are already #'Metric'() records, skip metrics_from_tuples
-    Metrics = filter_undefined_metrics(Metrics0),
     #'MetricFamily'{
         name = ensure_binary_or_string(Name),
         help = ensure_binary_or_string(Help),
         type = ensure_mf_type(Type),
-        metric = Metrics
+        metric = [M || M <- Metrics0, M =/= undefined]
     };
 create_mf(Name, Help, Type, Metrics0) ->
     Metrics = metrics_from_tuples(Type, Metrics0),
@@ -389,10 +387,7 @@ histogram_bucket({Bound, Count}) ->
     }.
 
 metrics_from_tuples(Type, Metrics) ->
-    [
-        metric_from_tuple(Type, Metric)
-     || Metric <- filter_undefined_metrics(ensure_list(Metrics))
-    ].
+    [metric_from_tuple(Type, M) || M <- ensure_list(Metrics), M =/= undefined].
 
 metric_from_tuple(_, Metric) when is_record(Metric, 'Metric') ->
     Metric;
@@ -412,14 +407,6 @@ metric_from_tuple(untyped, Metric) ->
 -spec ensure_list(Val :: term()) -> list().
 ensure_list(Val) when is_list(Val) -> Val;
 ensure_list(Val) -> [Val].
-
-?DOC(false).
--spec filter_undefined_metrics([undefined | T]) -> [T].
-filter_undefined_metrics(Metrics) ->
-    lists:filter(fun not_undefined/1, Metrics).
-
-not_undefined(undefined) -> false;
-not_undefined(_) -> true.
 
 ?DOC(false).
 -spec ensure_binary_or_string(Val :: term()) -> binary() | string().

--- a/src/model/prometheus_model_helpers.erl
+++ b/src/model/prometheus_model_helpers.erl
@@ -53,6 +53,8 @@ Probably will be used with `m:prometheus_collector`.
 
 -include("prometheus_model.hrl").
 
+-compile({inline, [label_pair/1, label_pair/2, gauge_metric/2, counter_metric/2]}).
+
 %%%===================================================================
 %%% Public API
 %%%===================================================================
@@ -100,6 +102,17 @@ Create Metric Family of `Type`, `Name` and `Help`.
     MetricFamily :: prometheus_model:'MetricFamily'().
 create_mf(Name, Help, Type, Metrics) when is_map(Metrics) ->
     create_mf(Name, Help, Type, maps:to_list(Metrics));
+create_mf(Name, Help, Type, [First | _] = Metrics0) when
+    is_list(Metrics0), is_record(First, 'Metric')
+->
+    %% Fast path: metrics are already #'Metric'() records, skip metrics_from_tuples
+    Metrics = filter_undefined_metrics(Metrics0),
+    #'MetricFamily'{
+        name = ensure_binary_or_string(Name),
+        help = ensure_binary_or_string(Help),
+        type = ensure_mf_type(Type),
+        metric = Metrics
+    };
 create_mf(Name, Help, Type, Metrics0) ->
     Metrics = metrics_from_tuples(Type, Metrics0),
     #'MetricFamily'{
@@ -340,15 +353,18 @@ fail with an error.
 label_pairs(B) when is_binary(B) ->
     B;
 label_pairs(Labels) when is_list(Labels) ->
-    lists:map(fun label_pair/1, Labels);
+    [label_pair(L) || L <- Labels];
 label_pairs(Labels) when is_map(Labels) ->
-    lists:map(fun label_pair/1, maps:to_list(Labels)).
+    [label_pair(Name, Value) || Name := Value <- Labels].
 
 ?DOC("""
 Creates `prometheus_model:`LabelPair'()' from \{Name, Value\} tuple.
 """).
 -spec label_pair(prometheus:label()) -> prometheus_model:'LabelPair'().
 label_pair({Name, Value}) ->
+    label_pair(Name, Value).
+
+label_pair(Name, Value) ->
     #'LabelPair'{
         name = ensure_binary_or_string(Name),
         value = ensure_binary_or_string(Value)
@@ -411,6 +427,8 @@ ensure_binary_or_string(Val) when is_atom(Val) -> atom_to_binary(Val, utf8);
 %% FIXME: validate utf8
 ensure_binary_or_string(Val) when is_list(Val) -> Val;
 ensure_binary_or_string(Val) when is_binary(Val) -> Val;
+ensure_binary_or_string(Val) when is_integer(Val) -> integer_to_binary(Val);
+ensure_binary_or_string(Val) when is_float(Val) -> float_to_binary(Val, [short]);
 ensure_binary_or_string(Val) -> io_lib:format("~p", [Val]).
 
 ?DOC(false).

--- a/src/prometheus_collector.erl
+++ b/src/prometheus_collector.erl
@@ -43,7 +43,7 @@ collect_mf(_Registry, Callback) ->
                           Memory)),
     ok.
 
-collect_metrics(erlang_vm_bytes_total, Memory) ->
+collect_metrics(_Name, Memory) ->
     prometheus_model_helpers:gauge_metrics(
       [
         {[{kind, system}], proplists:get_value(system,  Memory)},

--- a/src/prometheus_metric.erl
+++ b/src/prometheus_metric.erl
@@ -147,10 +147,10 @@ insert_new_mf(Table, Module, Spec) ->
     Module :: atom(),
     Spec :: spec().
 insert_mf(Table, Module, Spec) ->
-    {Registry, Name, Labels, Help, CLabels, DurationUnit, Data} =
+    {Registry, Name, Labels, _Help, CLabels, DurationUnit, Data, NameBin, HelpBin} =
         prometheus_metric_spec:extract_common_params(Spec),
     prometheus_registry:register_collector(Registry, Module),
-    Tuple = {{Registry, mf, Name}, {Labels, Help}, CLabels, DurationUnit, Data},
+    Tuple = {{Registry, mf, Name}, {Labels, HelpBin, NameBin}, CLabels, DurationUnit, Data},
     case ets:insert_new(Table, Tuple) of
         true ->
             maybe_set_default(Module, Registry, Name, Labels),
@@ -189,7 +189,8 @@ check_mf_exists(Table, Registry, Name, LabelValues) ->
     case ets:lookup(Table, {Registry, mf, Name}) of
         [] ->
             erlang:error({unknown_metric, Registry, Name});
-        [{_, {Labels, _}, _, _, _} = MF] ->
+        [{_, E2, _, _, _} = MF] ->
+            Labels = element(1, E2),
             LVLength = length(LabelValues),
             case length(Labels) of
                 LVLength ->
@@ -215,8 +216,7 @@ check_mf_exists(Table, Registry, Name) ->
 ?DOC(false).
 -spec mf_labels(tuple()) -> dynamic().
 mf_labels(MF) ->
-    {Labels, _} = element(2, MF),
-    Labels.
+    element(1, element(2, MF)).
 
 ?DOC(false).
 -spec mf_constant_labels(tuple()) -> dynamic().
@@ -236,7 +236,23 @@ mf_data(MF) ->
 ?DOC(false).
 -spec metrics(ets:table(), prometheus_registry:registry()) -> dynamic().
 metrics(Table, Registry) ->
-    ets:match(Table, {{Registry, mf, '$1'}, '$2', '$3', '$4', '$5'}).
+    Rows = ets:match(Table, {{Registry, mf, '$1'}, '$2', '$3', '$4', '$5'}),
+    [normalize_mf_row(Row) || Row <- Rows].
+
+normalize_mf_row([Name, {Labels, HelpBin, NameBin}, C, D, Data]) when
+    is_binary(NameBin), is_binary(HelpBin)
+->
+    [Name, {Labels, HelpBin, NameBin}, C, D, Data];
+normalize_mf_row([Name, {Labels, Help}, C, D, Data]) ->
+    %% Backward compat: old ETS data had 2-tuple; normalize on read
+    [
+        Name,
+        {Labels, prometheus_metric_spec:normalize_to_binary(Help),
+            prometheus_metric_spec:normalize_to_binary(Name)},
+        C,
+        D,
+        Data
+    ].
 
 %%====================================================================
 %% Private Parts

--- a/src/prometheus_metric_spec.erl
+++ b/src/prometheus_metric_spec.erl
@@ -20,7 +20,8 @@
     help/1,
     constant_labels/1,
     duration_unit/1,
-    extract_common_params/1
+    extract_common_params/1,
+    normalize_to_binary/1
 ]).
 
 -ifdef(TEST).
@@ -95,14 +96,16 @@ duration_unit_from_spec(Spec) ->
 
 ?DOC(false).
 -spec extract_common_params(Spec :: prometheus_metric:spec()) -> Return when
-    Return :: {Registry, Name, Labels, Help, CallTimeout, DurationUnit, Data},
+    Return :: {Registry, Name, Labels, Help, CallTimeout, DurationUnit, Data, NameBin, HelpBin},
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
     Labels :: prometheus_metric:labels(),
     Help :: prometheus_metric:help(),
     CallTimeout :: [{atom(), term()}],
     DurationUnit :: prometheus_time:maybe_duration_unit(),
-    Data :: dynamic().
+    Data :: dynamic(),
+    NameBin :: binary(),
+    HelpBin :: binary().
 extract_common_params(Spec) ->
     Registry = registry(Spec),
     Name = name(Spec),
@@ -111,7 +114,18 @@ extract_common_params(Spec) ->
     Data = data(Spec),
     CallTimeout = constant_labels(Spec),
     DurationUnit = duration_unit(Spec),
-    {Registry, Name, Labels, Help, CallTimeout, DurationUnit, Data}.
+    NameBin = normalize_to_binary(Name),
+    HelpBin = normalize_to_binary(Help),
+    {Registry, Name, Labels, Help, CallTimeout, DurationUnit, Data, NameBin, HelpBin}.
+
+?DOC(false).
+-spec normalize_to_binary(Val :: term()) -> binary().
+normalize_to_binary(Val) when is_binary(Val) -> Val;
+normalize_to_binary(Val) when is_atom(Val) -> atom_to_binary(Val, utf8);
+normalize_to_binary(Val) when is_list(Val) -> iolist_to_binary(Val);
+normalize_to_binary(Val) when is_integer(Val) -> integer_to_binary(Val);
+normalize_to_binary(Val) when is_float(Val) -> float_to_binary(Val, [short]);
+normalize_to_binary(Val) -> iolist_to_binary(io_lib:format("~p", [Val])).
 
 ?DOC(false).
 ?DOC(#{equiv => get_value(Key, Spec, undefined)}).

--- a/test/eunit/prometheus_metric_spec_tests.erl
+++ b/test/eunit/prometheus_metric_spec_tests.erl
@@ -189,14 +189,14 @@ extract_common_params_test() ->
     ),
 
     ?assertEqual(
-        {default, "qwe", [], "qwe", [], undefined, undefined},
+        {default, "qwe", [], "qwe", [], undefined, undefined, <<"qwe">>, <<"qwe">>},
         prometheus_metric_spec:extract_common_params([
             {name, "qwe"},
             {help, "qwe"}
         ])
     ),
     ?assertEqual(
-        {qwe, "qwe", ["qwe"], "qwe", [{qwe, qwa}], undefined, data},
+        {qwe, "qwe", ["qwe"], "qwe", [{qwe, qwa}], undefined, data, <<"qwe">>, <<"qwe">>},
         prometheus_metric_spec:extract_common_params([
             {name, "qwe"},
             {labels, ["qwe"]},

--- a/test/eunit/prometheus_model_helpers_tests.erl
+++ b/test/eunit/prometheus_model_helpers_tests.erl
@@ -661,6 +661,27 @@ create_mf_test() ->
         prometheus_model_helpers:create_mf(<<"fast_path">>, <<"help">>, gauge, [PrebuiltMetric])
     ).
 
+%% Test that prometheus_metric:metrics/2 normalizes old-format ETS entries
+%% (2-tuple {Labels, Help}) into the new 3-tuple {Labels, HelpBin, NameBin}.
+%% This covers the backward-compat clause in normalize_mf_row/1, reachable
+%% during hot upgrades from nodes that predate the pre-computed binary change.
+normalize_mf_row_backward_compat_test() ->
+    Table = ?PROMETHEUS_GAUGE_TABLE,
+    Registry = test_compat_registry,
+    Name = test_compat_metric,
+    Labels = [label_a],
+    Help = "Old format help",
+    OldTuple = {{Registry, mf, Name}, {Labels, Help}, [], undefined, undefined},
+    ets:insert(Table, OldTuple),
+    try
+        [[Name, {Labels, HelpBin, NameBin}, [], undefined, undefined]] =
+            prometheus_metric:metrics(Table, Registry),
+        ?assertEqual(<<"Old format help">>, HelpBin),
+        ?assertEqual(<<"test_compat_metric">>, NameBin)
+    after
+        ets:delete(Table, {Registry, mf, Name})
+    end.
+
 collect_metrics(g1, _Data) ->
     prometheus_model_helpers:gauge_metric(g1_value).
 

--- a/test/eunit/prometheus_model_helpers_tests.erl
+++ b/test/eunit/prometheus_model_helpers_tests.erl
@@ -585,7 +585,8 @@ ensure_binary_or_string_test() ->
     ?assertEqual(<<"qwe">>, prometheus_model_helpers:ensure_binary_or_string(qwe)),
     ?assertEqual("qwe", prometheus_model_helpers:ensure_binary_or_string("qwe")),
     ?assertEqual(<<"qwe">>, prometheus_model_helpers:ensure_binary_or_string(<<"qwe">>)),
-    ?assertEqual(["2"], prometheus_model_helpers:ensure_binary_or_string(2)).
+    ?assertEqual(<<"2">>, prometheus_model_helpers:ensure_binary_or_string(2)),
+    ?assertEqual(<<"1.5">>, prometheus_model_helpers:ensure_binary_or_string(1.5)).
 
 create_mf_test() ->
     ?assertMatch(
@@ -651,6 +652,21 @@ create_mf_test() ->
             ]
         },
         create_mf(<<"create_mf_with_map">>, "help", gauge, #{#{<<"l1">> => <<"v1">>} => my_value})
+    ),
+
+    %% Fast path: list of #'Metric'() is used as-is (no metrics_from_tuples)
+    PrebuiltMetric = #'Metric'{
+        label = [#'LabelPair'{name = <<"k">>, value = <<"v">>}],
+        gauge = #'Gauge'{value = 42}
+    },
+    ?assertMatch(
+        #'MetricFamily'{
+            name = <<"fast_path">>,
+            help = <<"help">>,
+            type = 'GAUGE',
+            metric = [PrebuiltMetric]
+        },
+        prometheus_model_helpers:create_mf(<<"fast_path">>, <<"help">>, gauge, [PrebuiltMetric])
     ).
 
 collect_metrics(g1, _Data) ->

--- a/test/eunit/prometheus_model_helpers_tests.erl
+++ b/test/eunit/prometheus_model_helpers_tests.erl
@@ -562,14 +562,6 @@ histogram_metric_test() ->
         prometheus_model_helpers:histogram_metric(LabelsMap, Buckets, Count, Sum)
     ).
 
-fitler_undefined_metrics_test() ->
-    ?assertEqual(
-        [1, 2, 3],
-        prometheus_model_helpers:filter_undefined_metrics(
-            [undefined, 1, undefined, 2, 3, undefined, undefined]
-        )
-    ).
-
 eunsure_mf_type_test() ->
     ?assertEqual('GAUGE', prometheus_model_helpers:ensure_mf_type(gauge)),
     ?assertEqual('COUNTER', prometheus_model_helpers:ensure_mf_type(counter)),


### PR DESCRIPTION
Profiling (tprof) of a RabbitMQ workload with ~2.3M metric series per scrape revealed that a significant portion of scrape time is spent on repeated conversions and intermediate allocations that can be avoided. This spawned from https://github.com/rabbitmq/rabbitmq-server/pull/14885, which spawned itself into https://github.com/prometheus-erl/prometheus.erl/pull/196. I have more changes in mind but they'll be breaking so for now this PR proposes only backwards-compatible stuff:

- Pre-compute metric name/help as binaries at declaration time — `atom_to_binary/iolist_to_binary` were called per metric family on every scrape; now done once at `insert_mf` time and stored in ETS. Includes backward-compat normalization for old ETS entries.
- Inline and fast-path metric record creation — `gauge_metric/2`, `counter_metric/2`, and `label_pair/1` are inlined (these are ~2M calls/scrape at 12 words each). A fast path in `create_mf/4` skips `metrics_from_tuples` dispatch when metrics are already `#'Metric'{}` records. Numeric clauses added to `ensure_binary_or_string/1` to avoid `io_lib:format` fallback.
- Merge filter and map into single list traversal — `metrics_from_tuples/2` previously ran `lists:filter/2` then a comprehension (two passes over ~2.4M elements, `lists:filter/2` alone at 3.26% of scrape time). Now a single comprehension with a guard.
- Inline `render_series/4` and `render_value/2` — called ~2.3M times each per scrape (~15.6% combined), inlining eliminates call overhead and enables cross-boundary binary append optimization.