### PR TITLE
Add API to set default value of labeled metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,36 @@ Common options are:
 
 Histogram also accepts `buckets` option. Please refer to respective modules docs for the more information.
 
+#### Default series
+
+Metrics with no labels automatically get a zero-value series created at declaration time.
+Metrics **with** labels do **not** create any series automatically — a series only appears after the
+first write (e.g. `inc`, `observe`, `set`).
+
+If you need a labeled series to be present in the output before the first write, call
+`prometheus_metric:set_default(MetricModule, Registry, Name, LabelValues)` explicitly:
+
+```erlang
+%% Declare a labeled counter
+prometheus_counter:declare([{name, http_requests_total}, {labels, [method]}, {help, ""}]),
+%% Pre-seed specific label combinations so they appear with value 0 immediately
+prometheus_metric:set_default(prometheus_counter, default, http_requests_total, [get]),
+prometheus_metric:set_default(prometheus_counter, default, http_requests_total, [post]).
+```
+
+If you are using the default registry, you can use the shorter
+`prometheus_metric:set_default(MetricModule, Name, LabelValues)` form:
+
+```erlang
+%% Equivalent to the previous example, but defaults Registry to `default`
+prometheus_metric:set_default(prometheus_counter, http_requests_total, [get]),
+prometheus_metric:set_default(prometheus_counter, http_requests_total, [post]).
+```
+
+Both `set_default/3` and `set_default/4` are idempotent: calling them again for an already-created series is a no-op.
+It raises `{unknown_metric, Registry, Name}` if the metric has not been declared, and
+`{invalid_metric_arity, Present, Expected}` if the label value count does not match.
+
 ### Exposition Formats
 
 - [`prometheus_text_format`](https://github.com/deadtrickster/prometheus.erl/blob/master/doc/prometheus_text_format.md) - renders metrics for a given registry (default is `default`) in text format;

--- a/src/metrics/prometheus_boolean.erl
+++ b/src/metrics/prometheus_boolean.erl
@@ -41,7 +41,7 @@ fuse_event(Fuse, Event) ->
     declare/1,
     deregister/1,
     deregister/2,
-    set_default/2,
+    set_default/3,
     set/2,
     set/3,
     set/4,
@@ -127,10 +127,22 @@ deregister(Registry, Name) ->
     NumDeleted = ets:select_delete(?TABLE, deregister_select(Registry, Name)),
     {MFR, NumDeleted > 0}.
 
-?DOC(false).
--spec set_default(prometheus_registry:registry(), prometheus_metric:name()) -> ok.
-set_default(Registry, Name) ->
-    set(Registry, Name, [], undefined).
+?DOC("""
+Pre-seeds a boolean series for `Registry`, `Name` and `LabelValues` with the value `undefined`,
+if the series does not yet exist.
+
+Raises:
+
+* `{unknown_metric, Registry, Name}` error if boolean with name `Name` can't be found in `Registry`.
+* `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
+""").
+-spec set_default(
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values()
+) -> ok.
+set_default(Registry, Name, LabelValues) ->
+    set(Registry, Name, LabelValues, undefined).
 
 ?DOC(#{equiv => set(default, Name, [], Value)}).
 -spec set(prometheus_metric:name(), prometheus:prometheus_boolean()) -> ok.

--- a/src/metrics/prometheus_counter.erl
+++ b/src/metrics/prometheus_counter.erl
@@ -58,7 +58,7 @@ inc(Caller) ->
     declare/1,
     deregister/1,
     deregister/2,
-    set_default/2,
+    set_default/3,
     inc/1,
     inc/2,
     inc/3,
@@ -146,10 +146,25 @@ deregister(Registry, Name) ->
     NumDeleted = ets:select_delete(?TABLE, deregister_select(Registry, Name)),
     {MFR, NumDeleted > 0}.
 
-?DOC(false).
--spec set_default(prometheus_registry:registry(), prometheus_metric:name()) -> boolean().
-set_default(Registry, Name) ->
-    ets:insert_new(?TABLE, {key(Registry, Name, []), 0, 0}).
+?DOC("""
+Pre-seeds a counter series for `Registry`, `Name` and `LabelValues` with an initial value of 0,
+if the series does not yet exist.
+
+Useful for ensuring a labeled series is present in output before any increments happen.
+
+Raises:
+
+* `{unknown_metric, Registry, Name}` error if counter with name `Name` can't be found in `Registry`.
+* `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
+""").
+-spec set_default(
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values()
+) -> boolean().
+set_default(Registry, Name, LabelValues) ->
+    prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
+    ets:insert_new(?TABLE, {key(Registry, Name, LabelValues), 0, 0}).
 
 ?DOC(#{equiv => inc(default, Name, [], 1)}).
 -spec inc(prometheus_metric:name()) -> ok.

--- a/src/metrics/prometheus_gauge.erl
+++ b/src/metrics/prometheus_gauge.erl
@@ -54,7 +54,7 @@ track_checked_out_sockets(CheckoutFun) ->
     declare/1,
     deregister/1,
     deregister/2,
-    set_default/2,
+    set_default/3,
     set/2,
     set/3,
     set/4,
@@ -161,10 +161,25 @@ deregister(Registry, Name) ->
     NumDeleted = ets:select_delete(?TABLE, deregister_select(Registry, Name)),
     {MFR, NumDeleted > 0}.
 
-?DOC(false).
--spec set_default(prometheus_registry:registry(), prometheus_metric:name()) -> boolean().
-set_default(Registry, Name) ->
-    ets:insert_new(?TABLE, {{Registry, Name, []}, 0, 0}).
+?DOC("""
+Pre-seeds a gauge series for `Registry`, `Name` and `LabelValues` with an initial value of 0,
+if the series does not yet exist.
+
+Useful for ensuring a labeled series is present in output before any updates happen.
+
+Raises:
+
+* `{unknown_metric, Registry, Name}` error if gauge with name `Name` can't be found in `Registry`.
+* `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
+""").
+-spec set_default(
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values()
+) -> boolean().
+set_default(Registry, Name, LabelValues) ->
+    prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
+    ets:insert_new(?TABLE, {{Registry, Name, LabelValues}, 0, 0}).
 
 ?DOC(#{equiv => set(default, Name, [], Value)}).
 -spec set(prometheus_metric:name(), number()) -> ok.

--- a/src/metrics/prometheus_histogram.erl
+++ b/src/metrics/prometheus_histogram.erl
@@ -52,7 +52,7 @@ the number of time ticks when the recent value was observed).
     declare/1,
     deregister/1,
     deregister/2,
-    set_default/2,
+    set_default/3,
     observe/2,
     observe/3,
     observe/4,
@@ -178,10 +178,24 @@ deregister(Registry, Name) ->
         _:_ -> {false, false}
     end.
 
-?DOC(false).
--spec set_default(prometheus_registry:registry(), prometheus_metric:name()) -> boolean().
-set_default(Registry, Name) ->
-    insert_placeholders(Registry, Name, []).
+?DOC("""
+Pre-seeds a histogram series for `Registry`, `Name` and `LabelValues` with zero-count buckets
+and zero sum, if the series does not yet exist.
+
+Useful for ensuring a labeled series is present in output before any observations happen.
+
+Raises:
+
+* `{unknown_metric, Registry, Name}` error if histogram with name `Name` can't be found in `Registry`.
+* `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
+""").
+-spec set_default(
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values()
+) -> boolean().
+set_default(Registry, Name, LabelValues) ->
+    insert_placeholders(Registry, Name, LabelValues).
 
 ?DOC(#{equiv => observe(default, Name, [], Value)}).
 -spec observe(prometheus_metric:name(), number()) -> ok.

--- a/src/metrics/prometheus_quantile_summary.erl
+++ b/src/metrics/prometheus_quantile_summary.erl
@@ -54,7 +54,7 @@ It takes `error` and `bound` as in `t:ddskerl_ets:opts/0`.
 -export([
     new/1,
     declare/1,
-    set_default/2,
+    set_default/3,
     deregister/1,
     deregister/2,
     observe/2,
@@ -122,11 +122,23 @@ declare(Spec) ->
     Spec1 = validate_summary_spec(Spec),
     prometheus_metric:insert_mf(?TABLE, ?MODULE, Spec1).
 
-?DOC(false).
--spec set_default(prometheus_registry:registry(), prometheus_metric:name()) -> boolean().
-set_default(Registry, Name) ->
-    #{error := Error, bound := Bound} = get_configuration(Registry, Name),
-    Key = key(Registry, Name, []),
+?DOC("""
+Pre-seeds a quantile summary series for `Registry`, `Name` and `LabelValues` with an empty
+initial state, if the series does not yet exist.
+
+Raises:
+
+* `{unknown_metric, Registry, Name}` error if summary with name `Name` can't be found in `Registry`.
+* `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
+""").
+-spec set_default(
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values()
+) -> boolean().
+set_default(Registry, Name, LabelValues) ->
+    #{error := Error, bound := Bound} = get_configuration(Registry, Name, LabelValues),
+    Key = key(Registry, Name, LabelValues),
     ddskerl_ets:new(?TABLE, Key, Error, Bound).
 
 ?DOC(#{equiv => deregister(default, Name)}).
@@ -472,8 +484,8 @@ insert_metric(Registry, Name, LabelValues, Key) ->
     Configuration = Configuration0#{name => Key},
     ddskerl_ets:new(Configuration).
 
-get_configuration(Registry, Name) ->
-    MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name),
+get_configuration(Registry, Name, LabelValues) ->
+    MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     prometheus_metric:mf_data(MF).
 
 key(Registry, Name, LabelValues) ->

--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -44,7 +44,7 @@ observe_response(Size) ->
     declare/1,
     deregister/1,
     deregister/2,
-    set_default/2,
+    set_default/3,
     observe/2,
     observe/3,
     observe/4,
@@ -133,10 +133,25 @@ deregister(Registry, Name) ->
     NumDeleted = ets:select_delete(?TABLE, deregister_select(Registry, Name)),
     {MFR, NumDeleted > 0}.
 
-?DOC(false).
--spec set_default(prometheus_registry:registry(), prometheus_metric:name()) -> boolean().
-set_default(Registry, Name) ->
-    ets:insert_new(?TABLE, {key(Registry, Name, []), 0, 0, 0}).
+?DOC("""
+Pre-seeds a summary series for `Registry`, `Name` and `LabelValues` with zero count and zero sum,
+if the series does not yet exist.
+
+Useful for ensuring a labeled series is present in output before any observations happen.
+
+Raises:
+
+* `{unknown_metric, Registry, Name}` error if summary with name `Name` can't be found in `Registry`.
+* `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
+""").
+-spec set_default(
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values()
+) -> boolean().
+set_default(Registry, Name, LabelValues) ->
+    prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
+    ets:insert_new(?TABLE, {key(Registry, Name, LabelValues), 0, 0, 0}).
 
 ?DOC(#{equiv => observe(default, Name, [], Value)}).
 -spec observe(prometheus_metric:name(), number()) -> ok.

--- a/src/prometheus_metric.erl
+++ b/src/prometheus_metric.erl
@@ -17,6 +17,8 @@ as well as handling metric labels and data.
 -export([
     insert_new_mf/3,
     insert_mf/3,
+    set_default/3,
+    set_default/4,
     deregister_mf/2,
     deregister_mf/3,
     check_mf_exists/3,
@@ -85,10 +87,11 @@ as well as handling metric labels and data.
 ?DOC("Inserts a new metric function into the table.").
 -callback declare(Spec :: spec()) -> boolean().
 
-?DOC("Sets the default metric function for the module.").
--callback set_default(Registry, Name) -> dynamic() when
-    Registry :: prometheus_registry:registry(),
-    Name :: name().
+?DOC("Sets the default (zero/initial) state for the metric series identified by Registry, Name and LabelValues.").
+-callback set_default(Registry :: prometheus_registry:registry(),
+                      Name :: name(),
+                      LabelValues :: label_values()) ->
+    dynamic().
 
 ?DOC("Removes a metric function by name.").
 -callback remove(Name :: name()) -> boolean() | no_return().
@@ -158,6 +161,20 @@ insert_mf(Table, Module, Spec) ->
         false ->
             false
     end.
+
+?DOC("Calls Module:set_default(default, Name, LabelValues). ").
+-spec set_default(Module :: module(), Name :: name(), LabelValues :: label_values()) -> dynamic().
+set_default(Module, Name, LabelValues) ->
+    set_default(Module, default, Name, LabelValues).
+
+?DOC("Calls Module:set_default(Registry, Name, LabelValues). ").
+-spec set_default(Module :: module(),
+                  Registry :: prometheus_registry:registry(),
+                  Name :: name(),
+                  LabelValues :: label_values()) ->
+    dynamic().
+set_default(Module, Registry, Name, LabelValues) ->
+    Module:set_default(Registry, Name, LabelValues).
 
 ?DOC(false).
 -spec deregister_mf(Table, Registry) -> boolean() | no_return() when
@@ -264,7 +281,7 @@ normalize_mf_row([Name, {Labels, Help}, C, D, Data]) ->
     Name :: name(),
     Labels :: list().
 maybe_set_default(Module, Registry, Name, []) ->
-    Module:set_default(Registry, Name);
+    set_default(Module, Registry, Name, []);
 maybe_set_default(_, _, _, _) ->
     ok.
 

--- a/test/eunit/metric/prometheus_boolean_tests.erl
+++ b/test/eunit/metric/prometheus_boolean_tests.erl
@@ -16,7 +16,8 @@ prometheus_format_test_() ->
         fun test_collector1/1,
         fun test_collector2/1,
         fun test_collector3/1,
-        fun test_values/1
+        fun test_values/1,
+        fun test_set_default_with_labels/1
     ]}.
 
 test_registration(_) ->
@@ -224,6 +225,31 @@ test_values(_) ->
                 {[{name, postgres}], false}
             ],
             lists:sort(prometheus_boolean:values(default, fuse_state))
+        )
+    ].
+
+test_set_default_with_labels(_) ->
+    prometheus_boolean:new([
+        {name, fuse_state},
+        {labels, [name]},
+        {help, "Fuse state"}
+    ]),
+    %% Before seeding: labeled series is undefined
+    Undef = prometheus_boolean:value(fuse_state, [myapp]),
+    %% Seed the labeled series
+    prometheus_boolean:set_default(default, fuse_state, [myapp]),
+    %% After seeding: labeled series returns undefined (boolean default)
+    Seeded = prometheus_boolean:value(fuse_state, [myapp]),
+    [
+        ?_assertEqual(undefined, Undef),
+        ?_assertEqual(undefined, Seeded),
+        ?_assertError(
+            {unknown_metric, default, unknown_boolean},
+            prometheus_boolean:set_default(default, unknown_boolean, [myapp])
+        ),
+        ?_assertError(
+            {invalid_metric_arity, 2, 1},
+            prometheus_boolean:set_default(default, fuse_state, [myapp, extra])
         )
     ].
 

--- a/test/eunit/metric/prometheus_counter_tests.erl
+++ b/test/eunit/metric/prometheus_counter_tests.erl
@@ -15,7 +15,8 @@ prometheus_format_test_() ->
         fun test_values/1,
         fun test_collector1/1,
         fun test_collector2/1,
-        fun test_collector3/1
+        fun test_collector3/1,
+        fun test_set_default_with_labels/1
     ]}.
 
 test_registration(_) ->
@@ -310,5 +311,35 @@ test_collector3(_) ->
                 }
             ],
             MFList
+        )
+    ].
+
+test_set_default_with_labels(_) ->
+    prometheus_counter:new([
+        {name, http_requests_total},
+        {labels, [method]},
+        {help, "Http request count"}
+    ]),
+    %% Before seeding: labeled series is undefined
+    Undef = prometheus_counter:value(http_requests_total, [get]),
+    %% Seed the labeled series
+    prometheus_counter:set_default(default, http_requests_total, [get]),
+    %% After seeding: labeled series returns 0
+    Seeded = prometheus_counter:value(http_requests_total, [get]),
+    %% Idempotent: second call returns false, series is still 0
+    Idempotent = prometheus_counter:set_default(default, http_requests_total, [get]),
+    AfterIdempotent = prometheus_counter:value(http_requests_total, [get]),
+    [
+        ?_assertEqual(undefined, Undef),
+        ?_assertEqual(0, Seeded),
+        ?_assertEqual(false, Idempotent),
+        ?_assertEqual(0, AfterIdempotent),
+        ?_assertError(
+            {unknown_metric, default, unknown_counter},
+            prometheus_counter:set_default(default, unknown_counter, [get])
+        ),
+        ?_assertError(
+            {invalid_metric_arity, 2, 1},
+            prometheus_counter:set_default(default, http_requests_total, [get, extra])
         )
     ].

--- a/test/eunit/metric/prometheus_gauge_tests.erl
+++ b/test/eunit/metric/prometheus_gauge_tests.erl
@@ -23,7 +23,8 @@ prometheus_format_test_() ->
         fun test_values/1,
         fun test_collector1/1,
         fun test_collector2/1,
-        fun test_collector3/1
+        fun test_collector3/1,
+        fun test_set_default_with_labels/1
     ]}.
 
 test_registration(_) ->
@@ -559,5 +560,35 @@ test_collector3(_) ->
                 }
             ],
             MFList
+        )
+    ].
+
+test_set_default_with_labels(_) ->
+    prometheus_gauge:new([
+        {name, pool_size},
+        {labels, [client]},
+        {help, "Pool size"}
+    ]),
+    %% Before seeding: labeled series is undefined
+    Undef = prometheus_gauge:value(pool_size, [redis]),
+    %% Seed the labeled series
+    prometheus_gauge:set_default(default, pool_size, [redis]),
+    %% After seeding: labeled series returns 0
+    Seeded = prometheus_gauge:value(pool_size, [redis]),
+    %% Idempotent: second call returns false, series is still 0
+    Idempotent = prometheus_gauge:set_default(default, pool_size, [redis]),
+    AfterIdempotent = prometheus_gauge:value(pool_size, [redis]),
+    [
+        ?_assertEqual(undefined, Undef),
+        ?_assertEqual(0, Seeded),
+        ?_assertEqual(false, Idempotent),
+        ?_assertEqual(0, AfterIdempotent),
+        ?_assertError(
+            {unknown_metric, default, unknown_gauge},
+            prometheus_gauge:set_default(default, unknown_gauge, [redis])
+        ),
+        ?_assertError(
+            {invalid_metric_arity, 2, 1},
+            prometheus_gauge:set_default(default, pool_size, [redis, extra])
         )
     ].

--- a/test/eunit/metric/prometheus_histogram_tests.erl
+++ b/test/eunit/metric/prometheus_histogram_tests.erl
@@ -21,7 +21,8 @@ prometheus_format_test_() ->
         fun test_values/1,
         fun test_collector1/1,
         fun test_collector2/1,
-        fun test_collector3/1
+        fun test_collector3/1,
+        fun test_set_default_with_labels/1
     ]}.
 
 test_registration_as_list(_) ->
@@ -780,5 +781,36 @@ test_collector3(_) ->
                 }
             ],
             MFList
+        )
+    ].
+
+test_set_default_with_labels(_) ->
+    prometheus_histogram:new([
+        {name, request_duration},
+        {labels, [method]},
+        {buckets, [5, 10]},
+        {help, "Request duration"}
+    ]),
+    %% Before seeding: labeled series is undefined
+    Undef = prometheus_histogram:value(request_duration, [get]),
+    %% Seed the labeled series
+    prometheus_histogram:set_default(default, request_duration, [get]),
+    %% After seeding: labeled series returns zero-count buckets and zero sum
+    Seeded = prometheus_histogram:value(request_duration, [get]),
+    %% Idempotent: second call returns false, seeded series is unchanged
+    Idempotent = prometheus_histogram:set_default(default, request_duration, [get]),
+    AfterIdempotent = prometheus_histogram:value(request_duration, [get]),
+    [
+        ?_assertEqual(undefined, Undef),
+        ?_assertEqual({[0, 0, 0], 0}, Seeded),
+        ?_assertEqual(false, Idempotent),
+        ?_assertEqual({[0, 0, 0], 0}, AfterIdempotent),
+        ?_assertError(
+            {unknown_metric, default, unknown_histogram},
+            prometheus_histogram:set_default(default, unknown_histogram, [get])
+        ),
+        ?_assertError(
+            {invalid_metric_arity, 2, 1},
+            prometheus_histogram:set_default(default, request_duration, [get, extra])
         )
     ].

--- a/test/eunit/metric/prometheus_quantile_summary_tests.erl
+++ b/test/eunit/metric/prometheus_quantile_summary_tests.erl
@@ -27,7 +27,8 @@ prometheus_format_test_() ->
         fun test_collector1/1,
         fun test_collector2/1,
         fun test_collector3/1,
-        fun test_merge_logic_when_fetching_value/1
+        fun test_merge_logic_when_fetching_value/1,
+        fun test_set_default_with_labels/1
     ]}.
 
 test_merge_logic_when_fetching_value(_) ->
@@ -48,6 +49,36 @@ test_merge_logic_when_fetching_value(_) ->
                     (abs(90 - Q90) =< 1) andalso
                     (abs(95 - Q95) =< 1),
             Value
+        )
+    ].
+
+test_set_default_with_labels(_) ->
+    prometheus_quantile_summary:new([
+        {name, orders_summary},
+        {labels, [department]},
+        {help, "Track orders count/total sum"}
+    ]),
+    %% Before seeding: labeled series is undefined
+    Undef = prometheus_quantile_summary:value(orders_summary, [electronics]),
+    %% Seed the labeled series
+    prometheus_quantile_summary:set_default(default, orders_summary, [electronics]),
+    %% After seeding: labeled series returns empty summary state
+    Seeded = prometheus_quantile_summary:value(orders_summary, [electronics]),
+    %% Idempotent: second call returns false, series is still empty summary state
+    Idempotent = prometheus_quantile_summary:set_default(default, orders_summary, [electronics]),
+    AfterIdempotent = prometheus_quantile_summary:value(orders_summary, [electronics]),
+    [
+        ?_assertEqual(undefined, Undef),
+        ?_assertMatch({0, 0, []}, Seeded),
+        ?_assertEqual(false, Idempotent),
+        ?_assertMatch({0, 0, []}, AfterIdempotent),
+        ?_assertError(
+            {unknown_metric, default, unknown_qsummary},
+            prometheus_quantile_summary:set_default(default, unknown_qsummary, [electronics])
+        ),
+        ?_assertError(
+            {invalid_metric_arity, 2, 1},
+            prometheus_quantile_summary:set_default(default, orders_summary, [electronics, extra])
         )
     ].
 

--- a/test/eunit/metric/prometheus_summary_tests.erl
+++ b/test/eunit/metric/prometheus_summary_tests.erl
@@ -17,7 +17,8 @@ prometheus_format_test_() ->
         fun test_values/1,
         fun test_collector1/1,
         fun test_collector2/1,
-        fun test_collector3/1
+        fun test_collector3/1,
+        fun test_set_default_with_labels/1
     ]}.
 
 test_registration(_) ->
@@ -412,5 +413,35 @@ test_collector3(_) ->
                 }
             ],
             MFList
+        )
+    ].
+
+test_set_default_with_labels(_) ->
+    prometheus_summary:new([
+        {name, orders_summary},
+        {labels, [department]},
+        {help, "Track orders count/total sum"}
+    ]),
+    %% Before seeding: labeled series is undefined
+    Undef = prometheus_summary:value(orders_summary, [electronics]),
+    %% Seed the labeled series
+    prometheus_summary:set_default(default, orders_summary, [electronics]),
+    %% After seeding: labeled series returns {0, 0}
+    Seeded = prometheus_summary:value(orders_summary, [electronics]),
+    %% Idempotent: second call returns false, series is still {0, 0}
+    Idempotent = prometheus_summary:set_default(default, orders_summary, [electronics]),
+    AfterIdempotent = prometheus_summary:value(orders_summary, [electronics]),
+    [
+        ?_assertEqual(undefined, Undef),
+        ?_assertEqual({0, 0}, Seeded),
+        ?_assertEqual(false, Idempotent),
+        ?_assertEqual({0, 0}, AfterIdempotent),
+        ?_assertError(
+            {unknown_metric, default, unknown_summary},
+            prometheus_summary:set_default(default, unknown_summary, [electronics])
+        ),
+        ?_assertError(
+            {invalid_metric_arity, 2, 1},
+            prometheus_summary:set_default(default, orders_summary, [electronics, extra])
         )
     ].

--- a/test/eunit/prometheus_metric_tests.erl
+++ b/test/eunit/prometheus_metric_tests.erl
@@ -1,0 +1,40 @@
+-module(prometheus_metric_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+prometheus_metric_test_() ->
+    {foreach, fun prometheus_eunit_common:start/0, fun prometheus_eunit_common:stop/1, [
+        fun test_set_default_proxy_default_registry/1,
+        fun test_set_default_proxy_explicit_registry/1,
+        fun test_set_default_proxy_unknown_metric/1
+    ]}.
+
+test_set_default_proxy_default_registry(_) ->
+    Name = metric_proxy_counter_default,
+    ok = prometheus_counter:new([{name, Name}, {labels, [status]}, {help, ""}]),
+    [
+        ?_assertEqual(true, prometheus_metric:set_default(prometheus_counter, Name, ["200"])),
+        ?_assertEqual(false, prometheus_metric:set_default(prometheus_counter, Name, ["200"])),
+        ?_assertEqual(0, prometheus_counter:value(Name, ["200"]))
+    ].
+
+test_set_default_proxy_explicit_registry(_) ->
+    Name = metric_proxy_counter_default_registry,
+    Registry = default,
+    ok = prometheus_counter:new([{registry, Registry}, {name, Name}, {labels, [status]}, {help, ""}]),
+    [
+        ?_assertEqual(true, prometheus_metric:set_default(prometheus_counter, Registry, Name, ["404"])),
+        ?_assertEqual(0, prometheus_counter:value(Registry, Name, ["404"]))
+    ].
+
+test_set_default_proxy_unknown_metric(_) ->
+    [
+        ?_assertError(
+            {unknown_metric, default, missing_metric_proxy_default},
+            prometheus_metric:set_default(prometheus_counter, missing_metric_proxy_default, [])
+        ),
+        ?_assertError(
+            {unknown_metric, default, missing_metric_proxy_custom},
+            prometheus_metric:set_default(prometheus_counter, default, missing_metric_proxy_custom, [])
+        )
+    ].


### PR DESCRIPTION
This PR adds a capability to initialize a metric with labels with a default value for specific label values. This is not done automatically, as label values are not known at the moment of metric creation, so it's up to the application whether these should be set to initial default value or not.